### PR TITLE
Add the status subresource to the image config

### DIFF
--- a/manifests/0000_05_config-operator_01_image.crd.yaml
+++ b/manifests/0000_05_config-operator_01_image.crd.yaml
@@ -11,3 +11,5 @@ spec:
     singular: image
     plural: images
     listKind: ImageList
+  subresources:
+    status: {}


### PR DESCRIPTION
This should reduce flakes on cluster-image-registry-operator CI.