### PR TITLE
Add manifest for Registry CRD

### DIFF
--- a/manifests/0000_05_config-operator_01_registry.crd.yaml
+++ b/manifests/0000_05_config-operator_01_registry.crd.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: registries.config.openshift.io
+spec:
+  group: config.openshift.io
+  scope: Cluster
+  names:
+    kind: Registry
+    singular: registry
+    plural: registries
+    listKind: RegistryList
+  versions:
+    - name: v1
+      served: true
+      storage: true


### PR DESCRIPTION
This manifest will be used for Registry CRs to set registries
for the builder pod and container runtime at a cluster level.

Continuation of https://github.com/openshift/api/pull/204

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>