### PR TITLE
crq: add status sub-resource

### DIFF
--- a/manifests/0000_03_quota-openshift_01_clusterresourcequota.crd.yaml
+++ b/manifests/0000_03_quota-openshift_01_clusterresourcequota.crd.yaml
@@ -10,6 +10,8 @@ spec:
     plural: clusterresourcequotas
     singular: clusterresourcequota
   scope: Cluster
+  subresources:
+    status: {}
   versions:
   - name: v1
     served: true


### PR DESCRIPTION
Missing this means openshift controller manager can't update status for cluster resource quota 🤦‍♂️ 