### PR TITLE
rbac: add aggregate-to-cluster-reader permissions

### DIFF
--- a/manifests/0000_05_config-operator_02_config.clusterrole.yaml
+++ b/manifests/0000_05_config-operator_02_config.clusterrole.yaml
@@ -1,0 +1,30 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+  name: system:openshift:cluster-config-operator:cluster-reader
+rules:
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  - authentications
+  - builds
+  - clusteroperators
+  - clusterversions
+  - consoles
+  - dnses
+  - featuregates
+  - images
+  - infrastructures
+  - ingresses
+  - networks
+  - oauths
+  - projects
+  - proxies
+  - schedulers
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
Adds a read permission for the cluster-reader-aggregate role for config.openshift.io objects.

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1697638

Old PR: https://github.com/openshift/origin/pull/22533