### PR TITLE
RBRs are Namespaced, and more nullable, update CRD

### DIFF
--- a/manifests/0000_03_authorization-openshift_01_rolebindingrestriction.crd.yaml
+++ b/manifests/0000_03_authorization-openshift_01_rolebindingrestriction.crd.yaml
@@ -11,7 +11,7 @@ spec:
     singular: rolebindingrestriction
   subresources:
     status: {}
-  scope: Cluster
+  scope: Namespaced
   versions:
   - name: v1
     served: true
@@ -45,12 +45,14 @@ spec:
                     whitelisted groups, the user is allowed to be bound to a role.
                   items:
                     type: string
+                  nullable: true
                   type: array
                 labels:
                   description: Selectors specifies a list of label selectors over
                     group labels.
                   items:
                     type: object
+                  nullable: true
                   type: array
               type: object
             serviceaccountrestriction:
@@ -89,12 +91,14 @@ spec:
                   description: Groups specifies a list of literal group names.
                   items:
                     type: string
+                  nullable: true
                   type: array
                 labels:
                   description: Selectors specifies a list of label selectors over
                     user labels.
                   items:
                     type: object
+                  nullable: true
                   type: array
                 users:
                   description: Users specifies a list of literal user names.

--- a/vendor/github.com/openshift/api/authorization/v1/generated.proto
+++ b/vendor/github.com/openshift/api/authorization/v1/generated.proto
@@ -116,9 +116,11 @@ message GroupRestriction {
   // Groups is a list of groups used to match against an individual user's
   // groups. If the user is a member of one of the whitelisted groups, the user
   // is allowed to be bound to a role.
+  // +nullable
   repeated string groups = 1;
 
   // Selectors specifies a list of label selectors over group labels.
+  // +nullable
   repeated k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector labels = 2;
 }
 
@@ -470,9 +472,10 @@ message UserRestriction {
   repeated string users = 1;
 
   // Groups specifies a list of literal group names.
+  // +nullable
   repeated string groups = 2;
 
   // Selectors specifies a list of label selectors over user labels.
+  // +nullable
   repeated k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector labels = 3;
 }
-

--- a/vendor/github.com/openshift/api/authorization/v1/types.go
+++ b/vendor/github.com/openshift/api/authorization/v1/types.go
@@ -493,9 +493,11 @@ type UserRestriction struct {
 	Users []string `json:"users" protobuf:"bytes,1,rep,name=users"`
 
 	// Groups specifies a list of literal group names.
+	// +nullable
 	Groups []string `json:"groups" protobuf:"bytes,2,rep,name=groups"`
 
 	// Selectors specifies a list of label selectors over user labels.
+	// +nullable
 	Selectors []metav1.LabelSelector `json:"labels" protobuf:"bytes,3,rep,name=labels"`
 }
 
@@ -505,9 +507,11 @@ type GroupRestriction struct {
 	// Groups is a list of groups used to match against an individual user's
 	// groups. If the user is a member of one of the whitelisted groups, the user
 	// is allowed to be bound to a role.
+	// +nullable
 	Groups []string `json:"groups" protobuf:"bytes,1,rep,name=groups"`
 
 	// Selectors specifies a list of label selectors over group labels.
+	// +nullable
 	Selectors []metav1.LabelSelector `json:"labels" protobuf:"bytes,2,rep,name=labels"`
 }
 


### PR DESCRIPTION
@damemi  I don't think I'll need to make any corresponding api change.  I don't see any namespace comment in openshift/api, I see nonNamespace, though.   
@deads2k thanks for the tip.  