### PR TITLE
Add manifest for imagecontentsourcepolicy CRD

### DIFF
--- a/manifests/0000_05_config-operator_01_imagecontentsourcepolicy.crd.yaml
+++ b/manifests/0000_05_config-operator_01_imagecontentsourcepolicy.crd.yaml
@@ -1,0 +1,48 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: imagecontentsourcepolicy.config.openshift.io
+spec:
+  group: config.openshift.io
+  scope: Cluster
+  names:
+    kind: ImageContentSourcePolicy
+    singular: imagecontentsourcepolicy
+    plural: imagecontentsourcepolicies
+    listKind: ImagecontentsourcepolicyList
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: Standard object's metadata.
+          type: object
+        spec:
+          description: spec holds user settable values for configuration
+          properties:
+            digestMappingRules:
+              description: DigestMappingRules contains configuration that determines
+                how the container runtime should check the image digest source.
+              properties:
+                sources:
+                  description: Sources are container image repository locations where digests could be sourced
+                  items:
+                    type: string
+                  type: array
+              type: object
+          type: object
+      required:
+      - spec


### PR DESCRIPTION
use imagecontentsourcepolicy to set sources of image digest for container runtime at a cluster level.

Signed-off-by: Qi Wang <qiwan@redhat.com>