### PR TITLE
specify status subresources for resources with empty status

### DIFF
--- a/manifests/0000_10_config-operator_01_apiserver.crd.yaml
+++ b/manifests/0000_10_config-operator_01_apiserver.crd.yaml
@@ -14,6 +14,8 @@ spec:
   - name: v1
     served: true
     storage: true
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/manifests/0000_10_config-operator_01_build.crd.yaml
+++ b/manifests/0000_10_config-operator_01_build.crd.yaml
@@ -14,6 +14,8 @@ spec:
   - name: v1
     served: true
     storage: true
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/manifests/0000_10_config-operator_01_dns.crd.yaml
+++ b/manifests/0000_10_config-operator_01_dns.crd.yaml
@@ -14,6 +14,8 @@ spec:
   - name: v1
     served: true
     storage: true
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/manifests/0000_10_config-operator_01_featuregate.crd.yaml
+++ b/manifests/0000_10_config-operator_01_featuregate.crd.yaml
@@ -15,6 +15,8 @@ spec:
   - name: v1
     served: true
     storage: true
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/manifests/0000_10_config-operator_01_ingress.crd.yaml
+++ b/manifests/0000_10_config-operator_01_ingress.crd.yaml
@@ -14,6 +14,8 @@ spec:
   - name: v1
     served: true
     storage: true
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/manifests/0000_10_config-operator_01_project.crd.yaml
+++ b/manifests/0000_10_config-operator_01_project.crd.yaml
@@ -14,6 +14,8 @@ spec:
     listKind: ProjectList
     plural: projects
     singular: project
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:

--- a/manifests/0000_10_config-operator_01_scheduler.crd.yaml
+++ b/manifests/0000_10_config-operator_01_scheduler.crd.yaml
@@ -14,6 +14,8 @@ spec:
   - name: v1
     served: true
     storage: true
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:


### PR DESCRIPTION
Some config resources have status without any values yet.  This makes sure we have separate endpoints before anything slips in.  I think our only remaining difficulty is infrastructure and networking.