### PR TITLE
ClusterResourceQuota: allow integer values

### DIFF
--- a/manifests/0000_03_quota-openshift_01_clusterresourcequota.crd.yaml
+++ b/manifests/0000_03_quota-openshift_01_clusterresourcequota.crd.yaml
@@ -410,7 +410,9 @@ spec:
               properties:
                 hard:
                   additionalProperties:
-                    type: string
+                    anyOf:
+                    - type: string
+                    - type: integer
                   description: 'hard is the set of desired hard limits for each named
                     resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/'
                   type: object

--- a/manifests/0000_03_quota-openshift_01_clusterresourcequota.crd.yaml-merge-patch
+++ b/manifests/0000_03_quota-openshift_01_clusterresourcequota.crd.yaml-merge-patch
@@ -1,0 +1,14 @@
+spec:
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            quota:
+              properties:
+                hard:
+                  additionalProperties:
+                    anyOf:
+                    - type: string
+                    - type: integer
+                    type: null


### PR DESCRIPTION
Like https://github.com/openshift/cluster-config-operator/pull/91, but for master.

Working around https://github.com/kubernetes-sigs/controller-tools/issues/328.

cc @damemi – this is another patch we need to port when using the controller-tools generator.