### PR TITLE
Migrate console extensions CRDs from console-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ clean:
 .PHONY: clean
 
 # Set crd-schema-gen variables
-CRD_SCHEMA_GEN_APIS := $(shell echo ./vendor/github.com/openshift/api/{authorization/v1,config/v1,quota/v1,security/v1,operator/v1alpha1})
+CRD_SCHEMA_GEN_APIS := $(shell echo ./vendor/github.com/openshift/api/{authorization/v1,config/v1,quota/v1,security/v1,operator/v1alpha1,console/v1})
 CRD_SCHEMA_GEN_VERSION :=v0.2.1
 
 update-codegen: update-codegen-crds

--- a/manifests/0000_10_config-operator_01_consoleclidownload.crd.yaml
+++ b/manifests/0000_10_config-operator_01_consoleclidownload.crd.yaml
@@ -1,0 +1,87 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: consoleclidownloads.console.openshift.io
+  annotations:
+    displayName: ConsoleCLIDownload
+    description: Extension for configuring openshift web console command line interface
+      (CLI) downloads.
+spec:
+  scope: Cluster
+  group: console.openshift.io
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  names:
+    plural: consoleclidownloads
+    singular: consoleclidownload
+    kind: ConsoleCLIDownload
+    listKind: ConsoleCLIDownloadList
+  additionalPrinterColumns:
+  - name: Display name
+    type: string
+    JSONPath: .spec.displayName
+  - name: Age
+    type: string
+    JSONPath: .metadata.creationTimestamp
+  - name: Description
+    type: string
+    JSONPath: .spec.description
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ConsoleCLIDownload is an extension for configuring openshift web
+        console command line interface (CLI) downloads.
+      type: object
+      required:
+      - spec
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: Standard object's metadata.
+          type: object
+        spec:
+          description: ConsoleCLIDownloadSpec is the desired cli download configuration.
+          type: object
+          required:
+          - description
+          - displayName
+          - links
+          properties:
+            description:
+              description: description is the description of the CLI download (can
+                include markdown).
+              type: string
+            displayName:
+              description: displayName is the display name of the CLI download.
+              type: string
+            links:
+              description: links is a list of objects that provide CLI download link
+                details.
+              type: array
+              items:
+                description: Represents a standard link that could be generated in
+                  HTML
+                type: object
+                required:
+                - href
+                - text
+                properties:
+                  href:
+                    description: href is the absolute secure URL for the link (must
+                      use https)
+                    type: string
+                  text:
+                    description: text is the display text for the link
+                    type: string

--- a/manifests/0000_10_config-operator_01_consoleexternalloglink.crd.yaml
+++ b/manifests/0000_10_config-operator_01_consoleexternalloglink.crd.yaml
@@ -1,0 +1,85 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: consoleexternalloglinks.console.openshift.io
+  annotations:
+    displayName: ConsoleExternalLogLinks
+    description: ConsoleExternalLogLink is an extension for customizing OpenShift
+      web console log links.
+spec:
+  scope: Cluster
+  group: console.openshift.io
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  names:
+    plural: consoleexternalloglinks
+    singular: consoleexternalloglink
+    kind: ConsoleExternalLogLink
+    listKind: ConsoleExternalLogLinkList
+  additionalPrinterColumns:
+  - name: Text
+    type: string
+    JSONPath: .spec.text
+  - name: HrefTemplate
+    type: string
+    JSONPath: .spec.hrefTemplate
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ConsoleExternalLogLink is an extension for customizing OpenShift
+        web console log links.
+      type: object
+      required:
+      - spec
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: Standard object's metadata.
+          type: object
+        spec:
+          description: ConsoleExternalLogLinkSpec is the desired log link configuration.
+            The log link will appear on the logs tab of the pod details page.
+          type: object
+          required:
+          - hrefTemplate
+          - text
+          properties:
+            hrefTemplate:
+              description: "hrefTemplate is an absolute secure URL (must use https)
+                for the log link including variables to be replaced. Variables are
+                specified in the URL with the format ${variableName}, for instance,
+                ${containerName} and will be replaced with the corresponding values
+                from the resource. Resource is a pod. Supported variables are: - ${resourceName}
+                - name of the resource which containes the logs - ${resourceUID} -
+                UID of the resource which contains the logs               - e.g. `11111111-2222-3333-4444-555555555555`
+                - ${containerName} - name of the resource's container that contains
+                the logs - ${resourceNamespace} - namespace of the resource that contains
+                the logs - ${podLabels} - JSON representation of labels matching the
+                pod with the logs             - e.g. `{\"key1\":\"value1\",\"key2\":\"value2\"}`
+                \n e.g., https://example.com/logs?resourceName=${resourceName}&containerName=${containerName}&resourceNamespace=${resourceNamespace}&podLabels=${podLabels}"
+              type: string
+            namespaceFilter:
+              description: namespaceFilter is a regular expression used to restrict
+                a log link to a matching set of namespaces (e.g., `^openshift-`).
+                The string is converted into a regular expression using the JavaScript
+                RegExp constructor. If not specified, links will be displayed for
+                all the namespaces.
+              type: string
+            text:
+              description: text is the display text for the link
+              type: string

--- a/manifests/0000_10_config-operator_01_consolelink.crd.yaml
+++ b/manifests/0000_10_config-operator_01_consolelink.crd.yaml
@@ -1,0 +1,107 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: consolelinks.console.openshift.io
+  annotations:
+    displayName: ConsoleLinks
+    description: Extension for customizing OpenShift web console links
+spec:
+  scope: Cluster
+  group: console.openshift.io
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  names:
+    plural: consolelinks
+    singular: consolelink
+    kind: ConsoleLink
+    listKind: ConsoleLinkList
+  additionalPrinterColumns:
+  - name: Text
+    type: string
+    JSONPath: .spec.text
+  - name: URL
+    type: string
+    JSONPath: .spec.href
+  - name: Menu
+    type: string
+    JSONPath: .spec.menu
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ConsoleLink is an extension for customizing OpenShift web console
+        links.
+      type: object
+      required:
+      - spec
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: Standard object's metadata.
+          type: object
+        spec:
+          description: ConsoleLinkSpec is the desired console link configuration.
+          type: object
+          required:
+          - href
+          - location
+          - text
+          properties:
+            applicationMenu:
+              description: applicationMenu holds information about section and icon
+                used for the link in the application menu, and it is applicable only
+                when location is set to ApplicationMenu.
+              type: object
+              required:
+              - section
+              properties:
+                imageURL:
+                  description: imageUrl is the URL for the icon used in front of the
+                    link in the application menu. The URL must be an HTTPS URL or
+                    a Data URI. The image should be square and will be shown at 24x24
+                    pixels.
+                  type: string
+                section:
+                  description: section is the section of the application menu in which
+                    the link should appear.
+                  type: string
+            href:
+              description: href is the absolute secure URL for the link (must use
+                https)
+              type: string
+            location:
+              description: location determines which location in the console the link
+                will be appended to.
+              type: string
+            namespaceDashboard:
+              description: namespaceDashboard holds information about namespaces in
+                which the dashboard link should appear, and it is applicable only
+                when location is set to NamespaceDashboard. If not specified, the
+                link will appear in all namespaces.
+              type: object
+              required:
+              - namespaces
+              properties:
+                namespaces:
+                  description: namespaces is an array of namespace names in which
+                    the dashboard link should appear.
+                  type: array
+                  items:
+                    type: string
+            text:
+              description: text is the display text for the link
+              type: string

--- a/manifests/0000_10_config-operator_01_consolenotification.crd.yaml
+++ b/manifests/0000_10_config-operator_01_consolenotification.crd.yaml
@@ -1,0 +1,87 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: consolenotifications.console.openshift.io
+  annotations:
+    displayName: ConsoleNotification
+    description: Extension for configuring openshift web console notifications.
+spec:
+  scope: Cluster
+  group: console.openshift.io
+  versions:
+  - name: v1
+    served: true
+    storage: true
+  names:
+    plural: consolenotifications
+    singular: consolenotification
+    kind: ConsoleNotification
+    listKind: ConsoleNotificationList
+  additionalPrinterColumns:
+  - name: Text
+    type: string
+    JSONPath: .spec.text
+  - name: Location
+    type: string
+    JSONPath: .spec.location
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ConsoleNotification is the extension for configuring openshift
+        web console notifications.
+      type: object
+      required:
+      - spec
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          description: Standard object's metadata.
+          type: object
+        spec:
+          description: ConsoleNotificationSpec is the desired console notification
+            configuration.
+          type: object
+          required:
+          - text
+          properties:
+            backgroundColor:
+              description: backgroundColor is the color of the background for the
+                notification as CSS data type color.
+              type: string
+            color:
+              description: color is the color of the text for the notification as
+                CSS data type color.
+              type: string
+            link:
+              description: link is an object that holds notification link details.
+              type: object
+              required:
+              - href
+              - text
+              properties:
+                href:
+                  description: href is the absolute secure URL for the link (must
+                    use https)
+                  type: string
+                text:
+                  description: text is the display text for the link
+                  type: string
+            location:
+              description: location is the location of the notification in the console.
+              type: string
+            text:
+              description: text is the visible text of the notification.
+              type: string


### PR DESCRIPTION
See https://github.com/openshift/console-operator/pull/302 for associated removal PR.  These files have existed in the console-operator, but should live here.

This is not a 1:1, however, due to `update-codegen-crds` modifying the files.

@spadgett @rhamilto @jhadvig fyi.

The `codegen` command overwrites these files based on what is in `openshift/api`, so what we previously had documented may no longer be here (if it was also not in `openshift/api`)