### PR TITLE
Enable TLS1.3 for go build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-config-operator
 COPY . .
 ENV GO_PACKAGE github.com/openshift/cluster-config-operator
-RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" ./cmd/cluster-config-operator
+RUN GODEBUG=tls13=1 go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" ./cmd/cluster-config-operator
 
 FROM registry.svc.ci.openshift.org/ocp/4.2:base
 RUN mkdir -p /usr/share/bootkube/manifests/manifests

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -2,7 +2,7 @@ FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-config-operator
 COPY . .
 ENV GO_PACKAGE github.com/openshift/cluster-config-operator
-RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" ./cmd/cluster-config-operator
+RUN GODEBUG=tls13=1 go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" ./cmd/cluster-config-operator
 
 FROM registry.svc.ci.openshift.org/ocp/4.2:base
 RUN mkdir -p /usr/share/bootkube/manifests/manifests


### PR DESCRIPTION
Image builds are failing with:
```
magebuilder build has begun; waiting for it to finish
--> FROM sha256:d721c86058dea92fcde74487fdf26c4c8a56224c996f9bb75f4c3845011d592f as builder
--> ADD atomic-reactor-repos/* '/etc/yum.repos.d/'
--> USER root
--> RUN mv -f /etc/yum.repos.d/ubi.repo /tmp || :
--> USER 0
--> ENV SOURCE_GIT_COMMIT=ad3efbbd55cbc6f7348f6845ae6d62ed75ee4159 SOURCE_DATE_EPOCH=1569873526 BUILD_VERSION=v4.3.0 SOURCE_GIT_URL=https://github.com/openshift/cluster-config-operator SOURCE_GIT_TAG=v0.0.0-alpha.0-170-gad3efbbd BUILD_RELEASE=201909302346
--> WORKDIR /go/src/github.com/openshift/cluster-config-operator
--> COPY . .
--> ENV GO_PACKAGE github.com/openshift/cluster-config-operator
--> RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" ./cmd/cluster-config-operator
# github.com/openshift/cluster-config-operator/vendor/k8s.io/component-base/cli/flag
vendor/k8s.io/component-base/cli/flag/ciphersuites_flag.go:80:18: undefined: tls.VersionTLS13
running 'go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" ./cmd/cluster-config-operator' failed with exit code 2
2019-10-01 05:59:16,921 - atomic_reactor.plugin - ERROR - Build step plugin imagebuilder failed: image build failed (rc=1): running 'go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" ./cmd/cluster-config-operator' failed with exit code 2
```

With Go 1.12 we need to explicitly opt in to TLS 1.3.