### PR TITLE
Makefile allow passing image tag to 'make images'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,15 @@ include $(addprefix ./vendor/github.com/openshift/library-go/alpha-build-machine
 	targets/openshift/crd-schema-gen.mk \
 )
 
+IMAGE_REGISTRY?=registry.svc.ci.openshift.org
+
 # This will call a macro called "build-image" which will generate image specific targets based on the parameters:
 # $0 - macro name
 # $1 - target suffix
 # $2 - Dockerfile path
 # $3 - context directory for image build
 # It will generate target "image-$(1)" for builing the image an binding it as a prerequisite to target "images".
-$(call build-image,ocp-cluster-config-operator,registry.svc.ci.openshift.org/ocp/4.2:cluster-config-operator,./Dockerfile,.)
+$(call build-image,ocp-cluster-config-operator,$(IMAGE_REGISTRY)/ocp/4.2:cluster-config-operator,./Dockerfile.rhel7,.)
 
 # This will call a macro called "add-bindata" which will generate bindata specific targets based on the parameters:
 # $0 - macro name


### PR DESCRIPTION
This allows passing a custom image registry to `make images`, like so:
`make IMAGE_REGISTRY=quay.io/sallyom images` 