### PR TITLE
Replace kube_apiserver_operator with config_operator in build_info

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -36,8 +36,8 @@ func Get() version.Info {
 func init() {
 	buildInfo := prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "openshift_cluster_kube_apiserver_operator_build_info",
-			Help: "A metric with a constant '1' value labeled by major, minor, git commit & git version from which OpenShift Cluster Kube-API-Server Operator was built.",
+			Name: "openshift_cluster_config_operator_build_info",
+			Help: "A metric with a constant '1' value labeled by major, minor, git commit & git version from which OpenShift Cluster Config Operator was built.",
 		},
 		[]string{"major", "minor", "gitCommit", "gitVersion"},
 	)


### PR DESCRIPTION
Replace `kube_apiserver_operator` with `config_operator` in `build_info` metric.

Looks like a small copy/paste error.  If there is a reason its reporting an `apiserver` metric, however, I will close. 

/assign @deads2k @damemi 