### PR TITLE
operator: move config metrics from kube-apiserver operator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/openshift/cluster-config-operator
 go 1.13
 
 require (
+	github.com/blang/semver v3.5.0+incompatible
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32 // indirect
 	github.com/json-iterator/go v1.1.9 // indirect
@@ -11,6 +12,7 @@ require (
 	github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160
 	github.com/openshift/client-go v0.0.0-20200320150128-a906f3d8e723
 	github.com/openshift/library-go v0.0.0-20200326104512-4dc124c2ddb8
+	github.com/prometheus/client_golang v1.1.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e // indirect

--- a/pkg/operator/metrics/config_metrics.go
+++ b/pkg/operator/metrics/config_metrics.go
@@ -1,0 +1,105 @@
+package metrics
+
+import (
+	"github.com/blang/semver"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/component-base/metrics/legacyregistry"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configinformers "github.com/openshift/client-go/config/informers/externalversions"
+	configlisters "github.com/openshift/client-go/config/listers/config/v1"
+)
+
+// Register exposes core platform metrics that relate to the configuration
+// of Kubernetes.
+func Register(configInformer configinformers.SharedInformerFactory) {
+	legacyregistry.MustRegister(&configMetrics{
+		infrastructureLister: configInformer.Config().V1().Infrastructures().Lister(),
+		cloudProvider: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cluster_infrastructure_provider",
+			Help: "Reports whether the cluster is configured with an infrastructure provider. type is unset if no cloud provider is recognized or set to the constant used by the Infrastructure config. region is set when the cluster clearly identifies a region within the provider. The value is 1 if a cloud provider is set or 0 if it is unset.",
+		}, []string{"type", "region"}),
+		featuregateLister: configInformer.Config().V1().FeatureGates().Lister(),
+		featureSet: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cluster_feature_set",
+			Help: "Reports the feature set the cluster is configured to expose. name corresponds to the featureSet field of the cluster. The value is 1 if a cloud provider is supported.",
+		}, []string{"name"}),
+		proxyLister: configInformer.Config().V1().Proxies().Lister(),
+		proxyEnablement: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "cluster_proxy_enabled",
+			Help: "Reports whether the cluster has been configured to use a proxy. type is which type of proxy configuration has been set - http for an http proxy, https for an https proxy, and trusted_ca if a custom CA was specified.",
+		}, []string{"type"}),
+	})
+}
+
+// configMetrics implements metrics gathering for this component.
+type configMetrics struct {
+	cloudProvider        *prometheus.GaugeVec
+	featureSet           *prometheus.GaugeVec
+	proxyEnablement      *prometheus.GaugeVec
+	infrastructureLister configlisters.InfrastructureLister
+	featuregateLister    configlisters.FeatureGateLister
+	proxyLister          configlisters.ProxyLister
+}
+
+func (m *configMetrics) FQName() string {
+	return prometheus.BuildFQName("", "", "cluster_config_metrics")
+}
+
+func (m *configMetrics) Create(_ *semver.Version) bool {
+	return true
+}
+
+// Describe reports the metadata for metrics to the prometheus collector.
+func (m *configMetrics) Describe(ch chan<- *prometheus.Desc) {
+	ch <- m.cloudProvider.WithLabelValues("", "").Desc()
+	ch <- m.featureSet.WithLabelValues("").Desc()
+	ch <- m.proxyEnablement.WithLabelValues("").Desc()
+}
+
+// Collect calculates metrics from the cached config and reports them to the prometheus collector.
+func (m *configMetrics) Collect(ch chan<- prometheus.Metric) {
+	if infra, err := m.infrastructureLister.Get("cluster"); err == nil {
+		if status := infra.Status.PlatformStatus; status != nil {
+			var g prometheus.Gauge
+			var value float64 = 1
+			switch {
+			// it is illegal to set type to empty string, so let the default case handle
+			// empty string (so we can detect it) while preserving the constant None here
+			case status.Type == configv1.NonePlatformType:
+				g = m.cloudProvider.WithLabelValues(string(status.Type), "")
+				value = 0
+			case status.AWS != nil:
+				g = m.cloudProvider.WithLabelValues(string(status.Type), status.AWS.Region)
+			case status.GCP != nil:
+				g = m.cloudProvider.WithLabelValues(string(status.Type), status.GCP.Region)
+			default:
+				g = m.cloudProvider.WithLabelValues(string(status.Type), "")
+			}
+			g.Set(value)
+			ch <- g
+		}
+	}
+	if features, err := m.featuregateLister.Get("cluster"); err == nil {
+		ch <- booleanGaugeValue(
+			m.featureSet.WithLabelValues(string(features.Spec.FeatureSet)),
+			features.Spec.FeatureSet == configv1.Default,
+		)
+	}
+	if proxy, err := m.proxyLister.Get("cluster"); err == nil {
+		ch <- booleanGaugeValue(m.proxyEnablement.WithLabelValues("http"), len(proxy.Spec.HTTPProxy) > 0)
+		ch <- booleanGaugeValue(m.proxyEnablement.WithLabelValues("https"), len(proxy.Spec.HTTPSProxy) > 0)
+		ch <- booleanGaugeValue(m.proxyEnablement.WithLabelValues("trusted_ca"), len(proxy.Spec.TrustedCA.Name) > 0)
+	}
+}
+
+func booleanGaugeValue(g prometheus.Gauge, value bool) prometheus.Gauge {
+	if value {
+		g.Set(1)
+	} else {
+		g.Set(0)
+	}
+	return g
+}
+
+func (m *configMetrics) ClearState() {}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -21,6 +21,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 
 	"github.com/openshift/cluster-config-operator/pkg/operator/aws_platform_service_location"
+	"github.com/openshift/cluster-config-operator/pkg/operator/metrics"
 )
 
 func RunOperator(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {
@@ -94,6 +95,8 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		}
 		return updateErr
 	}).ToController("ConfigOperatorController", controllerContext.EventRecorder)
+
+	metrics.Register(configInformers)
 
 	go dynamicInformers.Start(ctx.Done())
 	go configInformers.Start(ctx.Done())


### PR DESCRIPTION
Move https://github.com/openshift/cluster-kube-apiserver-operator/tree/master/pkg/operator/configmetrics to this operator as this is the logical place to have them. 

I'm interested how the prometheus will handle this transition, when for short time both metrics will exists.