### PR TITLE
manifests: fix metrics labels

### DIFF
--- a/manifests/0000_30_config-operator_02_service.yaml
+++ b/manifests/0000_30_config-operator_02_service.yaml
@@ -4,7 +4,7 @@ metadata:
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: config-operator-serving-cert
   labels:
-    app: config-operator
+    app: openshift-config-operator
   name: metrics
   namespace: openshift-config-operator
 spec:
@@ -14,6 +14,6 @@ spec:
     protocol: TCP
     targetPort: 8443
   selector:
-    app: config-operator
+    app: openshift-config-operator
   sessionAffinity: None
   type: ClusterIP

--- a/manifests/0000_30_config-operator_03_servicemonitor.yaml
+++ b/manifests/0000_30_config-operator_03_servicemonitor.yaml
@@ -18,5 +18,5 @@ spec:
     - openshift-config-operator
   selector:
     matchLabels:
-      app: config-operator
+      app: openshift-config-operator
 


### PR DESCRIPTION
Without this fix the prometheus won't see the config operator metrics endpoint and the target will be down.