### PR TITLE
Bug 1825944: kube_cloud_config: enforce the target key in config map to cloud.conf

### DIFF
--- a/pkg/operator/kube_cloud_config/aws.go
+++ b/pkg/operator/kube_cloud_config/aws.go
@@ -37,6 +37,8 @@ func awsTransformer(input *corev1.ConfigMap, key string, infra *configv1.Infrast
 	output := input.DeepCopy()
 	output.Namespace = operatorclient.GlobalMachineSpecifiedConfigNamespace
 	output.Name = targetConfigName
+	delete(output.Data, key)
+	delete(output.BinaryData, key)
 
 	inCfgRaw := &bytes.Buffer{}
 	if v, ok := input.Data[key]; ok {
@@ -68,14 +70,14 @@ func awsTransformer(input *corev1.ConfigMap, key string, infra *configv1.Infrast
 	}
 
 	if _, ok := input.Data[key]; ok {
-		output.Data[key] = inCfgRaw.String() // store the config to same as input
+		output.Data[targetConfigKey] = inCfgRaw.String() // store the config to same as input
 	} else if _, ok := input.BinaryData[key]; ok {
-		output.BinaryData[key] = inCfgRaw.Bytes() // store the config to same as input
+		output.BinaryData[targetConfigKey] = inCfgRaw.Bytes() // store the config to same as input
 	} else {
 		if output.Data == nil {
 			output.Data = map[string]string{}
 		}
-		output.Data[key] = inCfgRaw.String() // store the new config to input key
+		output.Data[targetConfigKey] = inCfgRaw.String() // store the new config to input key
 	}
 
 	return output, nil

--- a/pkg/operator/kube_cloud_config/aws_test.go
+++ b/pkg/operator/kube_cloud_config/aws_test.go
@@ -104,7 +104,7 @@ func Test_awsTransformer(t *testing.T) {
 		err:      `invalid platform, expected to be AWS`,
 	}, {
 		name:       "non empty config map, non aws infra",
-		inputcm:    &corev1.ConfigMap{Data: map[string]string{"cloud.conf": `{"resource-group": "test-rg"}`}},
+		inputcm:    &corev1.ConfigMap{Data: map[string]string{"config": `{"resource-group": "test-rg"}`}},
 		inputinfra: &configv1.Infrastructure{Status: configv1.InfrastructureStatus{Platform: configv1.AzurePlatformType, PlatformStatus: &configv1.PlatformStatus{Type: configv1.AzurePlatformType, Azure: &configv1.AzurePlatformStatus{ResourceGroupName: "test-rg"}}}},
 
 		outputcm: nil,
@@ -125,7 +125,7 @@ func Test_awsTransformer(t *testing.T) {
 		err:      ``,
 	}, {
 		name: "non empty config map, aws infra",
-		inputcm: &corev1.ConfigMap{Data: map[string]string{"cloud.conf": `[Global]
+		inputcm: &corev1.ConfigMap{Data: map[string]string{"config": `[Global]
 VPC = vpc-test
 SubnetID = subnet-test
 `}},
@@ -151,7 +151,7 @@ SubnetID = subnet-test
 		err: ``,
 	}, {
 		name: "non empty config map, aws infra with service endpoints",
-		inputcm: &corev1.ConfigMap{Data: map[string]string{"cloud.conf": `[Global]
+		inputcm: &corev1.ConfigMap{Data: map[string]string{"config": `[Global]
 VPC = vpc-test
 SubnetID = subnet-test
 `}},
@@ -189,7 +189,7 @@ SubnetID = subnet-test
 		err: ``,
 	}, {
 		name: "non empty config map, aws infra with service endpoints",
-		inputcm: &corev1.ConfigMap{Data: map[string]string{"cloud.conf": `[Global]
+		inputcm: &corev1.ConfigMap{Data: map[string]string{"config": `[Global]
 VPC = vpc-test
 SubnetID = subnet-test
 `}},
@@ -221,7 +221,7 @@ SubnetID = subnet-test
 		err:      `status\.platformStatus\.aws\.region: Required value: region is required to be set for AWS platform`,
 	}, {
 		name: "non empty config map, aws infra with service endpoints, no region",
-		inputcm: &corev1.ConfigMap{Data: map[string]string{"cloud.conf": `[Global]
+		inputcm: &corev1.ConfigMap{Data: map[string]string{"config": `[Global]
 VPC = vpc-test
 SubnetID = subnet-test
 `}},
@@ -231,7 +231,7 @@ SubnetID = subnet-test
 		err:      `status\.platformStatus\.aws\.region: Required value: region is required to be set for AWS platform`,
 	}, {
 		name: "non empty config map, aws infra with service endpoints",
-		inputcm: &corev1.ConfigMap{BinaryData: map[string][]byte{"cloud.conf": []byte(`[Global]
+		inputcm: &corev1.ConfigMap{BinaryData: map[string][]byte{"config": []byte(`[Global]
 VPC = vpc-test
 SubnetID = subnet-test
 `)}},
@@ -254,7 +254,7 @@ SubnetID = subnet-test
 			"cloud.ca": `-----BUNDLE-----
 -----END BUNDLE----
 `,
-			"cloud.conf": `[Global]
+			"config": `[Global]
 VPC = vpc-test
 SubnetID = subnet-test
 `}},
@@ -278,7 +278,7 @@ SubnetID = subnet-test
 	}, {
 		name: "non empty config map, aws infra with service endpoints",
 		inputcm: &corev1.ConfigMap{
-			Data: map[string]string{"cloud.conf": `[Global]
+			Data: map[string]string{"config": `[Global]
 VPC = vpc-test
 SubnetID = subnet-test
 `},
@@ -306,7 +306,7 @@ SubnetID = subnet-test
 		err: ``,
 	}, {
 		name: "non empty config map, aws infra with service endpoints, conflict",
-		inputcm: &corev1.ConfigMap{Data: map[string]string{"cloud.conf": `[Global]
+		inputcm: &corev1.ConfigMap{Data: map[string]string{"config": `[Global]
 VPC = vpc-test
 SubnetID = subnet-test
 
@@ -322,7 +322,7 @@ SubnetID = subnet-test
 		err:      `invalid user provided cloud.conf: user provided cloud.conf and infrastructure object both include service overrides`,
 	}, {
 		name: "non empty config map, aws infra with service endpoints, conflict",
-		inputcm: &corev1.ConfigMap{Data: map[string]string{"cloud.conf": `[Global]
+		inputcm: &corev1.ConfigMap{Data: map[string]string{"config": `[Global]
 VPC = vpc-test
 SubnetID = subnet-test
 
@@ -340,7 +340,7 @@ SubnetID = subnet-test
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-			outputcm, err := awsTransformer(test.inputcm, "cloud.conf", test.inputinfra)
+			outputcm, err := awsTransformer(test.inputcm, "config", test.inputinfra)
 			if test.err == "" {
 				assert.NoError(t, err)
 				outputcm.ObjectMeta = metav1.ObjectMeta{}

--- a/pkg/operator/kube_cloud_config/controller_test.go
+++ b/pkg/operator/kube_cloud_config/controller_test.go
@@ -1,0 +1,79 @@
+package kube_cloud_config
+
+import (
+	"testing"
+
+	"github.com/openshift/cluster-config-operator/pkg/operator/operatorclient"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_asIsTransformer(t *testing.T) {
+	cases := []struct {
+		input, output *corev1.ConfigMap
+	}{{
+		input:  &corev1.ConfigMap{},
+		output: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: targetConfigName, Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace}},
+	}, {
+		input:  &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "something", Namespace: "something-else"}},
+		output: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: targetConfigName, Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace}},
+	}, {
+		input: &corev1.ConfigMap{
+			Data: map[string]string{"config": "someval"},
+		},
+		output: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: targetConfigName, Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace},
+			Data:       map[string]string{"cloud.conf": "someval"},
+		},
+	}, {
+		input: &corev1.ConfigMap{
+			BinaryData: map[string][]byte{"config": []byte("someval")},
+		},
+		output: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: targetConfigName, Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace},
+			BinaryData: map[string][]byte{"cloud.conf": []byte("someval")},
+		},
+	}, {
+		input: &corev1.ConfigMap{
+			Data: map[string]string{"config": "someval", "ca-bundle": "bundle"},
+		},
+		output: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: targetConfigName, Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace},
+			Data:       map[string]string{"cloud.conf": "someval", "ca-bundle": "bundle"},
+		},
+	}, {
+		input: &corev1.ConfigMap{
+			Data:       map[string]string{"config": "someval"},
+			BinaryData: map[string][]byte{"ca-bundle": []byte("bundle")},
+		},
+		output: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: targetConfigName, Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace},
+			Data:       map[string]string{"cloud.conf": "someval"},
+			BinaryData: map[string][]byte{"ca-bundle": []byte("bundle")},
+		},
+	}, {
+		input: &corev1.ConfigMap{
+			Data: map[string]string{"ca-bundle": "bundle"},
+		},
+		output: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: targetConfigName, Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace},
+			Data:       map[string]string{"ca-bundle": "bundle"},
+		},
+	}, {
+		input: &corev1.ConfigMap{
+			BinaryData: map[string][]byte{"ca-bundle": []byte("bundle")},
+		},
+		output: &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: targetConfigName, Namespace: operatorclient.GlobalMachineSpecifiedConfigNamespace},
+			BinaryData: map[string][]byte{"ca-bundle": []byte("bundle")},
+		},
+	}}
+	for _, test := range cases {
+		t.Run("", func(t *testing.T) {
+			got, err := asIsTransformer(test.input, "config", nil)
+			assert.NoError(t, err)
+			assert.EqualValues(t, test.output, got)
+		})
+	}
+}


### PR DESCRIPTION
The infrastructure.config.openshift.io/v1 requires that the key for cloud config in the generated config map be `cloud.conf`.
Previously the controller was just copying and not enforcing the target key.

no both the as-is and aws transformers enforce this, and also the tests were updated to check that.