### PR TITLE
Fix 4.4 build failure

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -7,7 +7,7 @@ RUN GODEBUG=tls13=1 go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit
 FROM registry.svc.ci.openshift.org/ocp/4.2:base
 RUN mkdir -p /usr/share/bootkube/manifests/manifests
 RUN mkdir -p /usr/share/bootkube/manifests/bootstrap-manifests
-COPY --from=builder /go/src/github.com/openshift/cluster-config-operator/vendor/github.com/openshift/api/config/v1/*_config-operator_*-.yaml /usr/share/bootkube/manifests/manifests
+COPY --from=builder /go/src/github.com/openshift/cluster-config-operator/vendor/github.com/openshift/api/config/v1/*_config-operator_*.yaml /usr/share/bootkube/manifests/manifests
 COPY --from=builder /go/src/github.com/openshift/cluster-config-operator/vendor/github.com/openshift/api/quota/v1/*.yaml /usr/share/bootkube/manifests/manifests
 COPY --from=builder /go/src/github.com/openshift/cluster-config-operator/vendor/github.com/openshift/api/security/v1/*.yaml /usr/share/bootkube/manifests/manifests
 COPY --from=builder /go/src/github.com/openshift/cluster-config-operator/vendor/github.com/openshift/api/authorization/v1/*.yaml /usr/share/bootkube/manifests/manifests


### PR DESCRIPTION
We got the following  error from the latest 4.4 ose-cluster-config-operator build:
```
2020-06-15 14:42:23,127 - atomic_reactor.plugins.imagebuilder - INFO - --> COPY --from=builder /go/src/github.com/openshift/cluster-config-operator/vendor/github.com/openshift/api/config/v1/*_config-operator_*-.yaml /usr/share/bootkube/manifests/manifests
2020-06-15 14:42:23,884 - atomic_reactor.plugins.imagebuilder - INFO - file does not exist
```
(extracted from http://download.eng.bos.redhat.com/brewroot/work/tasks/9876/29399876/x86_64.log)
Seems to me that `https://github.com/openshift/cluster-config-operator/blob/release-4.4/Dockerfile.rhel7#L10` has an extra `-` before .yaml . Not sure if my guessing is true or anything is missing. Could you guys have a look?