### PR TITLE
Eliminate the SCC priority dependency using specific securityContext

### DIFF
--- a/manifests/0000_30_config-operator_07_deployment.yaml
+++ b/manifests/0000_30_config-operator_07_deployment.yaml
@@ -31,6 +31,8 @@ spec:
         terminationMessagePolicy: FallbackToLogsOnError
         image: quay.io/openshift/origin-cluster-config-operator:v4.0
         imagePullPolicy: IfNotPresent
+        securityContext:
+          runAsUser: 0
         command: ["cluster-config-operator", "operator"]
         ports:
           - containerPort: 8443


### PR DESCRIPTION
* Version: OCP4.5+, I met this issue, when OCP4.5 OTA is upgraded. But it can affect other previous versions either.
* Description:
    `openshift-config-operator` SA is bound with `cluster-admin` clusterrole, it allows all SCC, it sometimes causes incorrect SCC selection unless specific SCC condtions.
    For instance, if `nonroot` SCC priority is changed as higher than `anyuid` SCC, the operator pod is failed due to applying `nonroot` SCC  and it make OTA upgrade fail either.
For suppressing this issue, specify `securityContext.runAsUser: 0` in order to select required `anyuid` SCC regardless of SCC `Priority`. SCC custom considers usually on OpenShift, so we should eliminate the potential dependency issue like this.

* Test details

Usually, `openshift-config-operator` pod is running with `anyuid` as follows.
```console
$ oc get pod -n openshift-config-operator
NAME                                         READY   STATUS    RESTARTS   AGE
openshift-config-operator-76dcdb6664-rcbnd   1/1     Running   0          21s

$ oc rsh openshift-config-operator-76dcdb6664-rcbnd id
uid=0(root) gid=0(root) groups=0(root)

$ oc get -n openshift-config-operator \
  pod openshift-config-operator-76dcdb6664-rcbnd -o yaml | grep "openshift.io/scc:"
    openshift.io/scc: anyuid
```

But, `nonroot` SCC is configured higher `Priority` than `anyuid`, it make `openshift-config-operator` pod fail to run. 
```
$ oc get scc -o custom-columns=NAME:.metadata.name,RUNASUSER:.runAsUser.type,PRIORITY:.priority
NAME               RUNASUSER          PRIORITY
anyuid             RunAsAny           10
hostaccess         MustRunAsRange     <nil>
hostmount-anyuid   RunAsAny           <nil>
hostnetwork        MustRunAsRange     <nil>
node-exporter      RunAsAny           <nil>
nonroot            MustRunAsNonRoot   20
privileged         RunAsAny           <nil>
restricted         MustRunAsRange     <nil>
```

```console    
$ oc delete pod -l app=openshift-config-operator -n openshift-config-operator

$ oc get pod -n openshift-config-operator
NAME                                         READY   STATUS                       RESTARTS   AGE
openshift-config-operator-76dcdb6664-ghfpl   0/1     CreateContainerConfigError   0          19s

$ oc get -n openshift-config-operator \
  pod openshift-config-operator-76dcdb6664-ghfpl -o yaml | grep "openshift.io/scc:"
    openshift.io/scc: nonroot
```

For suppressing this, `openshift-config-operator` should run with specific condition for selection `anyuid` SCC.
```console
$ oc edit deploy openshift-config-operator -n openshift-config-operator
        securityContext:
          runAsUser: 0

$ oc get pod -n openshift-config-operator
NAME                                         READY   STATUS    RESTARTS   AGE
openshift-config-operator-74b797676b-cglbk   1/1     Running   0          70s

$ oc rsh -n openshift-config-operator openshift-config-operator-74b797676b-cglbk id
uid=0(root) gid=0(root) groups=0(root)

$ oc get -n openshift-config-operator \
  pod openshift-config-operator-74b797676b-cglbk -o yaml | grep "openshift.io/scc:"
    openshift.io/scc: anyuid
```