### PR TITLE
Bug 1878648: oauth: audit log oauthaccesstokens if fresh 4.6 install

### DIFF
--- a/empty-resources/0000_05_config-operator_02_apiserver.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_apiserver.cr.yaml
@@ -4,4 +4,6 @@ metadata:
   name: cluster
   annotations:
     release.openshift.io/create-only: "true"
+    # this flag is not set for a cluster coming from 4.5 via upgrade. Hence, 4.5 clusters will keep supporting non-sha256 tokens.
+    oauth-apiserver.openshift.io/secure-token-storage: "true"
 spec: {}


### PR DESCRIPTION
Final PR to activate deep oauth token audit logging from https://github.com/openshift/library-go/pull/894 for new 4.6 clusters.

Compare:

- https://github.com/openshift/cluster-openshift-apiserver-operator/pull/392
- https://github.com/openshift/cluster-authentication-operator/pull/324