### PR TITLE
Bug 1879492: Add secure access token annotation controller to handle downgrade from 4.6

### DIFF
--- a/pkg/operator/secureaccesstoken/controller.go
+++ b/pkg/operator/secureaccesstoken/controller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"time"
 
-	configv1 "github.com/openshift/api/config/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
 	"github.com/openshift/library-go/pkg/controller/factory"
@@ -42,7 +41,6 @@ func NewController(operatorClient operatorv1helpers.OperatorClient,
 func (c Controller) sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	obj, err := c.apiserverLister.Get("cluster")
 	if errors.IsNotFound(err) {
-		syncCtx.Recorder().Warningf("SecureAccessTokenAnnotationController", "Required apiservers.%s/cluster not found", configv1.GroupName)
 		return nil
 	}
 	if err != nil {

--- a/pkg/operator/secureaccesstoken/controller.go
+++ b/pkg/operator/secureaccesstoken/controller.go
@@ -1,0 +1,61 @@
+package secureaccesstoken
+
+import (
+	"context"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const secureTokenStorageAnnotationKey = "oauth-apiserver.openshift.io/secure-token-storage"
+
+// Controller removes the "oauth-apiserver.openshift.io/secure-token-storage"
+// annotation from the APIServer config/v1 object after a potential downgrade from 4.6.
+type Controller struct {
+	apiserverClient configv1client.APIServerInterface
+	apiserverLister configlistersv1.APIServerLister
+}
+
+// NewController returns a new secure access token annotation removal controller.
+func NewController(operatorClient operatorv1helpers.OperatorClient,
+	apiserverClient configv1client.APIServerInterface, apiserverLister configlistersv1.APIServerLister, apiserverInformer factory.Informer,
+	recorder events.Recorder) factory.Controller {
+	c := &Controller{
+		apiserverClient: apiserverClient,
+		apiserverLister: apiserverLister,
+	}
+	return factory.New().
+		WithInformers(apiserverInformer).
+		WithSync(c.sync).
+		WithSyncDegradedOnError(operatorClient).
+		ResyncEvery(time.Minute).
+		ToController("SecureAccessTokenAnnotationController", recorder)
+}
+
+func (c Controller) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	obj, err := c.apiserverLister.Get("cluster")
+	if errors.IsNotFound(err) {
+		syncCtx.Recorder().Warningf("SecureAccessTokenAnnotationController", "Required apiservers.%s/cluster not found", configv1.GroupName)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	if _, ok := obj.Annotations[secureTokenStorageAnnotationKey]; !ok {
+		return nil
+	}
+
+	updated := obj.DeepCopy()
+	delete(updated.Annotations, secureTokenStorageAnnotationKey)
+
+	_, err = c.apiserverClient.Update(ctx, updated, metav1.UpdateOptions{})
+	return err
+}


### PR DESCRIPTION
The annotation oauth-apiserver.openshift.io/secure-token-storage: true set on the config/v1 apiserver object make openshift-apiserver deeply log oauth tokens, noth access and authorize (if openshift-apiserver is responsible for this; in fresh 4.6 install it is not, but oauth-apiserver is).

This requires that there are no non-sha256 tokens in the system. For 4.6 installs this is guaranteed.

This PR adds a controller to remove the "oauth-apiserver.openshift.io/secure-token-storage" annotation from the APIServer config/v1 object after a potential downgrade from 4.6, to allow for the fact that non-sha256 are created on 4.5.

Counterpart to 4.6 PRs:

- https://github.com/openshift/library-go/pull/894 (merged already)
- https://github.com/openshift/cluster-openshift-apiserver-operator/pull/392
- https://github.com/openshift/cluster-authentication-operator/pull/324
- https://github.com/openshift/cluster-config-operator/pull/152