### PR TITLE
Bug 1883898: add service ca operator to log level controller resource list

### DIFF
--- a/pkg/operator/operatorloglevel/loglevel_controller.go
+++ b/pkg/operator/operatorloglevel/loglevel_controller.go
@@ -122,6 +122,11 @@ func (c *operatorLogLevelNormalizer) sync(ctx context.Context, syncCtx factory.S
 			Version:  "v1",
 			Resource: "clustercsidrivers",
 		},
+		{
+			Group:    "operator.openshift.io",
+			Version:  "v1",
+			Resource: "servicecas",
+		},
 	}
 
 	for _, gvr := range gvrs {


### PR DESCRIPTION
This PR adds the missing service ca operator resource to the list of resources used by log level controller.