### PR TITLE
Add IBM Cloud managed annotations to CVO manifests

### DIFF
--- a/empty-resources/0000_05_config-operator_02_apiserver.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_apiserver.cr.yaml
@@ -3,6 +3,7 @@ kind: APIServer
 metadata:
   name: cluster
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     # this flag is not set for a cluster coming from 4.5 via upgrade. Hence, 4.5 clusters will keep supporting non-sha256 tokens.

--- a/empty-resources/0000_05_config-operator_02_authentication.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_authentication.cr.yaml
@@ -3,6 +3,7 @@ kind: Authentication
 metadata:
   name: cluster
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"

--- a/empty-resources/0000_05_config-operator_02_build.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_build.cr.yaml
@@ -3,6 +3,7 @@ kind: Build
 metadata:
   name: cluster
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"

--- a/empty-resources/0000_05_config-operator_02_console.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_console.cr.yaml
@@ -3,6 +3,7 @@ kind: Console
 metadata:
   name: cluster
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"

--- a/empty-resources/0000_05_config-operator_02_dns.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_dns.cr.yaml
@@ -3,6 +3,7 @@ kind: DNS
 metadata:
   name: cluster
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"

--- a/empty-resources/0000_05_config-operator_02_featuregate.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_featuregate.cr.yaml
@@ -3,6 +3,7 @@ kind: FeatureGate
 metadata:
   name: cluster
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"

--- a/empty-resources/0000_05_config-operator_02_image.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_image.cr.yaml
@@ -3,6 +3,7 @@ kind: Image
 metadata:
   name: cluster
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"

--- a/empty-resources/0000_05_config-operator_02_infrastructure.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_infrastructure.cr.yaml
@@ -3,6 +3,7 @@ kind: Infrastructure
 metadata:
   name: cluster
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"

--- a/empty-resources/0000_05_config-operator_02_ingress.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_ingress.cr.yaml
@@ -3,6 +3,7 @@ kind: Ingress
 metadata:
   name: cluster
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"

--- a/empty-resources/0000_05_config-operator_02_network.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_network.cr.yaml
@@ -3,6 +3,7 @@ kind: Network
 metadata:
   name: cluster
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"

--- a/empty-resources/0000_05_config-operator_02_oauth.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_oauth.cr.yaml
@@ -3,6 +3,7 @@ kind: OAuth
 metadata:
   name: cluster
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"

--- a/empty-resources/0000_05_config-operator_02_operatorhub.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_operatorhub.cr.yaml
@@ -3,6 +3,7 @@ kind: OperatorHub
 metadata:
   name: cluster
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"

--- a/empty-resources/0000_05_config-operator_02_project.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_project.cr.yaml
@@ -3,6 +3,7 @@ kind: Project
 metadata:
   name: cluster
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"

--- a/empty-resources/0000_05_config-operator_02_proxy.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_proxy.cr.yaml
@@ -3,6 +3,7 @@ kind: Proxy
 metadata:
   name: cluster
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"

--- a/empty-resources/0000_05_config-operator_02_scheduler.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_scheduler.cr.yaml
@@ -3,6 +3,7 @@ kind: Scheduler
 metadata:
   name: cluster
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"

--- a/manifests/0000_10_config-operator_01_openshift-config-managed-ns.yaml
+++ b/manifests/0000_10_config-operator_01_openshift-config-managed-ns.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""

--- a/manifests/0000_10_config-operator_01_openshift-config-ns.yaml
+++ b/manifests/0000_10_config-operator_01_openshift-config-ns.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""

--- a/manifests/0000_10_config-operator_02_config.clusterrole.yaml
+++ b/manifests/0000_10_config-operator_02_config.clusterrole.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:

--- a/manifests/0000_30_config-operator_00_namespace.yaml
+++ b/manifests/0000_30_config-operator_00_namespace.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""

--- a/manifests/0000_30_config-operator_01_operator.cr.yaml
+++ b/manifests/0000_30_config-operator_01_operator.cr.yaml
@@ -3,6 +3,7 @@ kind: Config
 metadata:
   name: cluster
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"

--- a/manifests/0000_30_config-operator_01_prometheusrole.yaml
+++ b/manifests/0000_30_config-operator_01_prometheusrole.yaml
@@ -5,6 +5,7 @@ metadata:
   name: prometheus-k8s
   namespace: openshift-config-operator
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 rules:

--- a/manifests/0000_30_config-operator_02_prometheusrolebinding.yaml
+++ b/manifests/0000_30_config-operator_02_prometheusrolebinding.yaml
@@ -4,6 +4,7 @@ metadata:
   name: prometheus-k8s
   namespace: openshift-config-operator
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 roleRef:

--- a/manifests/0000_30_config-operator_02_service.yaml
+++ b/manifests/0000_30_config-operator_02_service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     service.alpha.openshift.io/serving-cert-secret-name: config-operator-serving-cert

--- a/manifests/0000_30_config-operator_03_servicemonitor.yaml
+++ b/manifests/0000_30_config-operator_03_servicemonitor.yaml
@@ -4,6 +4,7 @@ metadata:
   name: config-operator
   namespace: openshift-config-operator
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/0000_30_config-operator_04_roles.yaml
+++ b/manifests/0000_30_config-operator_04_roles.yaml
@@ -3,6 +3,7 @@ kind: ClusterRoleBinding
 metadata:
   name: system:openshift:operator:openshift-config-operator
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 roleRef:

--- a/manifests/0000_30_config-operator_05_serviceaccount.yaml
+++ b/manifests/0000_30_config-operator_05_serviceaccount.yaml
@@ -4,6 +4,7 @@ metadata:
   namespace: openshift-config-operator
   name: openshift-config-operator
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
   labels:


### PR DESCRIPTION
This matches https://github.com/openshift/enhancements/pull/445 and does not change behavior.

- Bump github.com/openshift/api (needed to include https://github.com/openshift/api/pull/781)
- Add IBM Cloud managed annotations to CVO manifests
