### PR TITLE
Bug 1915473: Annotate manifests for single-node-developer cluster profile

### DIFF
--- a/empty-resources/0000_05_config-operator_02_apiserver.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_apiserver.cr.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cluster
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     # this flag is not set for a cluster coming from 4.5 via upgrade. Hence, 4.5 clusters will keep supporting non-sha256 tokens.
     oauth-apiserver.openshift.io/secure-token-storage: "true"
     release.openshift.io/create-only: "true"

--- a/empty-resources/0000_05_config-operator_02_authentication.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_authentication.cr.yaml
@@ -4,5 +4,6 @@ metadata:
   name: cluster
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_build.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_build.cr.yaml
@@ -4,5 +4,6 @@ metadata:
   name: cluster
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_console.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_console.cr.yaml
@@ -4,5 +4,6 @@ metadata:
   name: cluster
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_dns.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_dns.cr.yaml
@@ -4,5 +4,6 @@ metadata:
   name: cluster
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_featuregate.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_featuregate.cr.yaml
@@ -4,5 +4,6 @@ metadata:
   name: cluster
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_image.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_image.cr.yaml
@@ -4,5 +4,6 @@ metadata:
   name: cluster
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_infrastructure.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_infrastructure.cr.yaml
@@ -4,5 +4,6 @@ metadata:
   name: cluster
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_ingress.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_ingress.cr.yaml
@@ -4,5 +4,6 @@ metadata:
   name: cluster
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_network.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_network.cr.yaml
@@ -4,5 +4,6 @@ metadata:
   name: cluster
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_oauth.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_oauth.cr.yaml
@@ -4,5 +4,6 @@ metadata:
   name: cluster
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_operatorhub.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_operatorhub.cr.yaml
@@ -4,5 +4,6 @@ metadata:
   name: cluster
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_project.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_project.cr.yaml
@@ -4,5 +4,6 @@ metadata:
   name: cluster
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_proxy.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_proxy.cr.yaml
@@ -4,5 +4,6 @@ metadata:
   name: cluster
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_scheduler.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_scheduler.cr.yaml
@@ -4,5 +4,6 @@ metadata:
   name: cluster
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
 spec: {}

--- a/manifests/0000_10_config-operator_01_openshift-config-managed-ns.yaml
+++ b/manifests/0000_10_config-operator_01_openshift-config-managed-ns.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
   name: openshift-config-managed
   labels:

--- a/manifests/0000_10_config-operator_01_openshift-config-ns.yaml
+++ b/manifests/0000_10_config-operator_01_openshift-config-ns.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
   name: openshift-config
   labels:

--- a/manifests/0000_10_config-operator_02_config.clusterrole.yaml
+++ b/manifests/0000_10_config-operator_02_config.clusterrole.yaml
@@ -3,6 +3,7 @@ kind: ClusterRole
 metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
   name: system:openshift:cluster-config-operator:cluster-reader

--- a/manifests/0000_30_config-operator_00_namespace.yaml
+++ b/manifests/0000_30_config-operator_00_namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/manifests/0000_30_config-operator_01_operator.cr.yaml
+++ b/manifests/0000_30_config-operator_01_operator.cr.yaml
@@ -4,6 +4,7 @@ metadata:
   name: cluster
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
 spec:
   managementState: Managed

--- a/manifests/0000_30_config-operator_01_prometheusrole.yaml
+++ b/manifests/0000_30_config-operator_01_prometheusrole.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: openshift-config-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - ""

--- a/manifests/0000_30_config-operator_02_prometheusrolebinding.yaml
+++ b/manifests/0000_30_config-operator_02_prometheusrolebinding.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-config-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/0000_30_config-operator_02_service.yaml
+++ b/manifests/0000_30_config-operator_02_service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     service.alpha.openshift.io/serving-cert-secret-name: config-operator-serving-cert
   labels:
     app: openshift-config-operator

--- a/manifests/0000_30_config-operator_03_servicemonitor.yaml
+++ b/manifests/0000_30_config-operator_03_servicemonitor.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-config-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/0000_30_config-operator_04_roles.yaml
+++ b/manifests/0000_30_config-operator_04_roles.yaml
@@ -4,6 +4,7 @@ metadata:
   name: system:openshift:operator:openshift-config-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   kind: ClusterRole
   name: cluster-admin

--- a/manifests/0000_30_config-operator_05_serviceaccount.yaml
+++ b/manifests/0000_30_config-operator_05_serviceaccount.yaml
@@ -5,5 +5,6 @@ metadata:
   name: openshift-config-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     app: openshift-config-operator

--- a/manifests/0000_30_config-operator_07_deployment.yaml
+++ b/manifests/0000_30_config-operator_07_deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     app: openshift-config-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   replicas: 1

--- a/manifests/0000_30_config-operator_08_clusteroperator.yaml
+++ b/manifests/0000_30_config-operator_08_clusteroperator.yaml
@@ -4,6 +4,7 @@ metadata:
   name: config-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec: {}
 status:


### PR DESCRIPTION
This partially implements phase 1 of https://github.com/openshift/enhancements#482
and does not change behavior. Initially, all cluster-config-operator
manifests are included in the single-node-developer cluster profile.
Follow-on PRs may exclude any of these that are not needed in the
profile.