### PR TITLE
add 'single-node-production-edge' annotations to CVO manifests.

### DIFF
--- a/empty-resources/0000_05_config-operator_02_apiserver.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_apiserver.cr.yaml
@@ -7,4 +7,5 @@ metadata:
     # this flag is not set for a cluster coming from 4.5 via upgrade. Hence, 4.5 clusters will keep supporting non-sha256 tokens.
     oauth-apiserver.openshift.io/secure-token-storage: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_authentication.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_authentication.cr.yaml
@@ -5,4 +5,5 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_build.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_build.cr.yaml
@@ -5,4 +5,5 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_console.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_console.cr.yaml
@@ -5,4 +5,5 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_dns.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_dns.cr.yaml
@@ -5,4 +5,5 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_featuregate.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_featuregate.cr.yaml
@@ -5,4 +5,5 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_image.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_image.cr.yaml
@@ -5,4 +5,5 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_infrastructure.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_infrastructure.cr.yaml
@@ -5,4 +5,5 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_ingress.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_ingress.cr.yaml
@@ -5,4 +5,5 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_network.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_network.cr.yaml
@@ -5,4 +5,5 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_oauth.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_oauth.cr.yaml
@@ -5,4 +5,5 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_operatorhub.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_operatorhub.cr.yaml
@@ -5,4 +5,5 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_project.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_project.cr.yaml
@@ -5,4 +5,5 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_proxy.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_proxy.cr.yaml
@@ -5,4 +5,5 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}

--- a/empty-resources/0000_05_config-operator_02_scheduler.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_scheduler.cr.yaml
@@ -5,4 +5,5 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}

--- a/manifests/0000_10_config-operator_01_openshift-config-managed-ns.yaml
+++ b/manifests/0000_10_config-operator_01_openshift-config-managed-ns.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
+    include.release.openshift.io/single-node-production-edge: "true"
   name: openshift-config-managed
   labels:
     openshift.io/run-level: "0"

--- a/manifests/0000_10_config-operator_01_openshift-config-ns.yaml
+++ b/manifests/0000_10_config-operator_01_openshift-config-ns.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
+    include.release.openshift.io/single-node-production-edge: "true"
   name: openshift-config
   labels:
     openshift.io/run-level: "0"

--- a/manifests/0000_10_config-operator_02_config.clusterrole.yaml
+++ b/manifests/0000_10_config-operator_02_config.clusterrole.yaml
@@ -3,6 +3,7 @@ kind: ClusterRole
 metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
   name: system:openshift:cluster-config-operator:cluster-reader

--- a/manifests/0000_30_config-operator_00_namespace.yaml
+++ b/manifests/0000_30_config-operator_00_namespace.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     openshift.io/cluster-monitoring: "true"
   name: openshift-config-operator

--- a/manifests/0000_30_config-operator_01_operator.cr.yaml
+++ b/manifests/0000_30_config-operator_01_operator.cr.yaml
@@ -5,5 +5,6 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   managementState: Managed

--- a/manifests/0000_30_config-operator_01_prometheusrole.yaml
+++ b/manifests/0000_30_config-operator_01_prometheusrole.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: openshift-config-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - ""

--- a/manifests/0000_30_config-operator_02_prometheusrolebinding.yaml
+++ b/manifests/0000_30_config-operator_02_prometheusrolebinding.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-config-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/0000_30_config-operator_02_service.yaml
+++ b/manifests/0000_30_config-operator_02_service.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     service.alpha.openshift.io/serving-cert-secret-name: config-operator-serving-cert
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     app: openshift-config-operator
   name: metrics

--- a/manifests/0000_30_config-operator_03_servicemonitor.yaml
+++ b/manifests/0000_30_config-operator_03_servicemonitor.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-config-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/manifests/0000_30_config-operator_04_roles.yaml
+++ b/manifests/0000_30_config-operator_04_roles.yaml
@@ -4,6 +4,7 @@ metadata:
   name: system:openshift:operator:openshift-config-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   kind: ClusterRole
   name: cluster-admin

--- a/manifests/0000_30_config-operator_05_serviceaccount.yaml
+++ b/manifests/0000_30_config-operator_05_serviceaccount.yaml
@@ -5,5 +5,6 @@ metadata:
   name: openshift-config-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     app: openshift-config-operator

--- a/manifests/0000_30_config-operator_07_deployment.yaml
+++ b/manifests/0000_30_config-operator_07_deployment.yaml
@@ -8,6 +8,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   replicas: 1
   strategy:

--- a/manifests/0000_30_config-operator_08_clusteroperator.yaml
+++ b/manifests/0000_30_config-operator_08_clusteroperator.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec: {}
 status:
   versions:


### PR DESCRIPTION
This adds annotations for the single-node-production-edge cluster profile. There's a growing requirement from several customers to enable creation of single-node (not high-available) Openshift clusters.
In stage one (following openshift/enhancements#504) there should be no implication on components logic.
In the next stage, the component's behavior will match a non high-availability profile if the customer is specifically interested in one.
This PR is separate from the 'single-node-developer' work, which will implement a different behavior and is currently on another stage of implementation.

For more info, please refer to the enhancement link and participate in the discussion.