### PR TITLE
pkg/operator/kube_cloud_config: Fix "kuberneted" -> "Kubernetes" doc typo

### DIFF
--- a/pkg/operator/kube_cloud_config/doc.go
+++ b/pkg/operator/kube_cloud_config/doc.go
@@ -1,3 +1,3 @@
-// Package kubecloudconfig controller is responsible for stitching the user provided kuberneted cloud configuration file and
+// Package kubecloudconfig controller is responsible for stitching the user-provided Kubernetes cloud configuration file and
 // the various platform specific settings provided in the infrastructures.config.openshift.io
 package kubecloudconfig


### PR DESCRIPTION
The typo is from a854f43ce1 (#120).