### PR TITLE
Mark operator pod as system-cluster-critical

### DIFF
--- a/manifests/0000_30_config-operator_07_deployment.yaml
+++ b/manifests/0000_30_config-operator_07_deployment.yaml
@@ -23,6 +23,7 @@ spec:
         app: openshift-config-operator
     spec:
       serviceAccountName: openshift-config-operator
+      priorityClassName: "system-cluster-critical"
       volumes:
       - name: serving-cert
         secret:


### PR DESCRIPTION
The config operator runs cluster-critical controllers.

Addressing https://github.com/openshift/origin/pull/25931.