### PR TITLE
Add management workload annotations

### DIFF
--- a/manifests/0000_30_config-operator_00_namespace.yaml
+++ b/manifests/0000_30_config-operator_00_namespace.yaml
@@ -5,6 +5,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
   name: openshift-config-operator

--- a/manifests/0000_30_config-operator_07_deployment.yaml
+++ b/manifests/0000_30_config-operator_07_deployment.yaml
@@ -19,6 +19,8 @@ spec:
   template:
     metadata:
       name: openshift-config-operator
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: openshift-config-operator
     spec:


### PR DESCRIPTION
In support of the workload partitioning feature
(openshift/enhancements#703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.

Signed-off-by: Artyom Lukianov <alukiano@redhat.com>