### PR TITLE
Bug 1949145: Add user facing priority class

### DIFF
--- a/manifests/0000_50_config-operator_09_user-priority-class.yaml
+++ b/manifests/0000_50_config-operator_09_user-priority-class.yaml
@@ -1,0 +1,7 @@
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: openshift-user-critical
+value: 1000000000
+globalDefault: false
+description: "This priority class should be used for user facing OpenShift workload pods only."


### PR DESCRIPTION
Add user facing critical priority class to CCO. This priority class is currently in [CMO](https://github.com/openshift/cluster-monitoring-operator/blob/master/manifests/0000_50_cluster-monitoring-operator_00_0user-priority-class.yaml), however we see that it is beneficial enough to be used by multiple entities like RHOAM, so moving it CCO.

cc @smarterclayton 