### PR TITLE
Bug 1949145: Add missing annotations to upc

### DIFF
--- a/manifests/0000_50_config-operator_09_user-priority-class.yaml
+++ b/manifests/0000_50_config-operator_09_user-priority-class.yaml
@@ -2,6 +2,9 @@ apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: openshift-user-critical
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 value: 1000000000
 globalDefault: false
 description: "This priority class should be used for user facing OpenShift workload pods only."


### PR DESCRIPTION
As part of #191, I missed adding required annotations to priority class manifest. Adding them now.

cc @soltysh 