### PR TITLE
Bug 1960339: manifests: add preemptionPolicy for openshift-user-critical

### DIFF
--- a/manifests/0000_50_config-operator_09_user-priority-class.yaml
+++ b/manifests/0000_50_config-operator_09_user-priority-class.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+preemptionPolicy: PreemptLowerPriority
 value: 1000000000
 globalDefault: false
 description: "This priority class should be used for user facing OpenShift workload pods only."


### PR DESCRIPTION
CVO hotloops on this manifest, applying preemptionPolicy post-install.

Found during hotloop verbose testing in CVO - https://github.com/openshift/cluster-version-operator/pull/561 ([log](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_cluster-version-operator/561/pull-ci-openshift-cluster-version-operator-master-e2e-agnostic/1392749307458752512/artifacts/e2e-agnostic/gather-extra/artifacts/pods/openshift-cluster-version_cluster-version-operator-9bc9644c5-tgd95_cluster-version-operator.log))