### PR TITLE
Bug 1960339: openshift-user-critical: unset globalDefault

### DIFF
--- a/manifests/0000_50_config-operator_09_user-priority-class.yaml
+++ b/manifests/0000_50_config-operator_09_user-priority-class.yaml
@@ -7,5 +7,4 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
 preemptionPolicy: PreemptLowerPriority
 value: 1000000000
-globalDefault: false
 description: "This priority class should be used for user facing OpenShift workload pods only."


### PR DESCRIPTION
This property doesn't render in the final object, so CVO hotloops attempting to set it.

Follow-up for https://github.com/openshift/cluster-config-operator/pull/202.
Verified that its no longer hotlooping via `test e2e openshift/cluster-version-operator#561,openshift/cluster-config-operator#205 aws` task in cluster-bot:
```
$ curl -sL https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/release-openshift-origin-installer-launch-aws/1400081719066890240/artifacts/launch/pods/openshift-cluster-version_cluster-version-operator-55b7ff6f99-5pz7v_cluster-version-operator.log | grep -oP "Updating \K.+ due to diff" | cut -d' ' -f1 | sort | uniq -c
     14 ClusterServiceVersion
    447 Deployment
```