### PR TITLE
Add missing include annotation for ibm-cloud-managed

### DIFF
--- a/manifests/0000_50_config-operator_09_user-priority-class.yaml
+++ b/manifests/0000_50_config-operator_09_user-priority-class.yaml
@@ -3,6 +3,7 @@ kind: PriorityClass
 metadata:
   name: openshift-user-critical
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 preemptionPolicy: PreemptLowerPriority


### PR DESCRIPTION
Adds missing include annotation in the user-priority-class manifest.