### PR TITLE
manifests/deployment: comply to restricted pod security level

### DIFF
--- a/manifests/0000_30_config-operator_07_deployment.yaml
+++ b/manifests/0000_30_config-operator_07_deployment.yaml
@@ -24,6 +24,11 @@ spec:
       labels:
         app: openshift-config-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: openshift-config-operator
       priorityClassName: "system-cluster-critical"
       volumes:
@@ -33,6 +38,10 @@ spec:
           optional: true
       containers:
       - name: openshift-config-operator
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
         terminationMessagePolicy: FallbackToLogsOnError
         image: quay.io/openshift/origin-cluster-config-operator:v4.0
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```
{
  "objectRef": "openshift-config-operator/deployments/openshift-config-operator",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"openshift-config-operator\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container \"openshift-config-operator\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"openshift-config-operator\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container \"openshift-config-operator\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}
```

/cc @stlaz 