### PR TITLE
Add Power VS CustomServiceController

### DIFF
--- a/pkg/operator/powervs_platform_custom_service/OWNERS
+++ b/pkg/operator/powervs_platform_custom_service/OWNERS
@@ -1,0 +1,5 @@
+reviewers:
+- mkumatag
+- Karthik-K-N
+approvers:
+- mkumatag

--- a/pkg/operator/powervs_platform_custom_service/controller.go
+++ b/pkg/operator/powervs_platform_custom_service/controller.go
@@ -1,0 +1,145 @@
+package powervs_platform_custom_service
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"sort"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/tools/cache"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+)
+
+// PowerVSPlatformCustomServiceController is responsible for syncing and validating the service endpoints for Power VS APIs
+// provided by the user using the infrastructure.config.openshift.io/cluster object.
+type PowerVSPlatformCustomServiceController struct {
+	infraClient configv1client.InfrastructureInterface
+	infraLister configlistersv1.InfrastructureLister
+}
+
+// NewController returns a new PowerVSPlatformCustomServiceController.
+func NewController(operatorClient operatorv1helpers.OperatorClient,
+	infraClient configv1client.InfrastructuresGetter, infraLister configlistersv1.InfrastructureLister, infraInformer cache.SharedIndexInformer,
+	recorder events.Recorder) factory.Controller {
+	c := &PowerVSPlatformCustomServiceController{
+		infraClient: infraClient.Infrastructures(),
+		infraLister: infraLister,
+	}
+	return factory.New().
+		WithInformers(
+			operatorClient.Informer(),
+			infraInformer,
+		).
+		WithSync(c.sync).
+		WithSyncDegradedOnError(operatorClient).
+		ResyncEvery(time.Minute).
+		ToController("PowerVSPlatformCustomServiceController", recorder)
+}
+
+func (c PowerVSPlatformCustomServiceController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	obj, err := c.infraLister.Get("cluster")
+	if errors.IsNotFound(err) {
+		syncCtx.Recorder().Warningf("PowerVSPlatformCustomServiceController", "Required infrastructures.%s/cluster not found", configv1.GroupName)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	currentInfra := obj.DeepCopy()
+	var platformName configv1.PlatformType
+	if pstatus := currentInfra.Status.PlatformStatus; pstatus != nil {
+		platformName = pstatus.Type
+	}
+	if len(platformName) == 0 {
+		syncCtx.Recorder().Warningf("PowerVSPlatformCustomServiceController", "Falling back to deprecated status.platform because infrastructures.%s/cluster status.platformStatus.type is empty", configv1.GroupName)
+		platformName = currentInfra.Status.Platform
+	}
+	if platformName != configv1.PowerVSPlatformType {
+		return nil // nothing to do here.
+	}
+
+	if currentInfra.Spec.PlatformSpec.Type != "" && currentInfra.Spec.PlatformSpec.Type != platformName {
+		return field.Invalid(field.NewPath("spec", "platformSpec", "type"), currentInfra.Spec.PlatformSpec.Type, fmt.Sprint("non Power VS platform type set in specification"))
+	}
+
+	var services []configv1.PowerVSServiceEndpoint
+	if currentInfra.Spec.PlatformSpec.PowerVS != nil {
+		services = append(services, currentInfra.Spec.PlatformSpec.PowerVS.ServiceEndpoints...)
+	}
+
+	if err := validateServiceEndpoints(services); err != nil {
+		syncCtx.Recorder().Warningf("PowerVSPlatformCustomServiceController", "Invalid spec.platformSpec.powervs.serviceEndpoints provided for infrastructures.%s/cluster", configv1.GroupName)
+		return err
+	}
+	sort.Slice(services, func(i, j int) bool {
+		return services[i].Name < services[j].Name
+	})
+
+	var existingServices []configv1.PowerVSServiceEndpoint
+	if currentInfra.Status.PlatformStatus != nil && currentInfra.Status.PlatformStatus.PowerVS != nil {
+		existingServices = append(existingServices, currentInfra.Status.PlatformStatus.PowerVS.ServiceEndpoints...)
+	}
+	if equality.Semantic.DeepEqual(existingServices, services) {
+		return nil // nothing to do now
+	}
+
+	if currentInfra.Status.PlatformStatus == nil {
+		currentInfra.Status.PlatformStatus = &configv1.PlatformStatus{}
+	}
+	if currentInfra.Status.PlatformStatus.PowerVS == nil {
+		currentInfra.Status.PlatformStatus.PowerVS = &configv1.PowerVSPlatformStatus{}
+	}
+	currentInfra.Status.PlatformStatus.PowerVS.ServiceEndpoints = services
+	_, err = c.infraClient.UpdateStatus(ctx, currentInfra, metav1.UpdateOptions{})
+	return err
+}
+
+func validateServiceEndpoints(endpoints []configv1.PowerVSServiceEndpoint) error {
+	fldPath := field.NewPath("spec", "platformSpec", "powervs", "serviceEndpoints")
+
+	allErrs := field.ErrorList{}
+	tracker := map[string]int{}
+	for idx, e := range endpoints {
+		fldp := fldPath.Index(idx)
+		if eidx, ok := tracker[e.Name]; ok {
+			allErrs = append(allErrs, field.Invalid(fldp.Child("name"), e.Name, fmt.Sprintf("duplicate service endpoint not allowed for %s, service endpoint already defined at %s", e.Name, fldPath.Index(eidx))))
+		} else {
+			tracker[e.Name] = idx
+		}
+
+		if err := validateServiceURL(e.URL); err != nil {
+			allErrs = append(allErrs, field.Invalid(fldp.Child("url"), e.URL, err.Error()))
+		}
+	}
+	return allErrs.ToAggregate()
+}
+
+func validateServiceURL(uri string) error {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return err
+	}
+	if u.Hostname() == "" {
+		return fmt.Errorf("host cannot be empty, empty host provided")
+	}
+	if s := u.Scheme; s != "https" {
+		return fmt.Errorf("invalid scheme %s, only https allowed", s)
+	}
+	if r := u.RequestURI(); r != "/" {
+		return fmt.Errorf("no path or request parameters must be provided, %q was provided", r)
+	}
+
+	return nil
+}

--- a/pkg/operator/powervs_platform_custom_service/controller_test.go
+++ b/pkg/operator/powervs_platform_custom_service/controller_test.go
@@ -1,0 +1,210 @@
+package powervs_platform_custom_service
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ktesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configfakeclient "github.com/openshift/client-go/config/clientset/versioned/fake"
+	configv1listers "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+)
+
+func modifier(orig *configv1.Infrastructure, modFn func(*configv1.Infrastructure)) *configv1.Infrastructure {
+	copy := orig.DeepCopy()
+	modFn(copy)
+	return copy
+}
+
+func Test_sync(t *testing.T) {
+	basicObj := &configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		Spec:       configv1.InfrastructureSpec{PlatformSpec: configv1.PlatformSpec{Type: configv1.PowerVSPlatformType}},
+		Status: configv1.InfrastructureStatus{
+			Platform: configv1.PowerVSPlatformType,
+			PlatformStatus: &configv1.PlatformStatus{
+				Type:    configv1.PowerVSPlatformType,
+				PowerVS: &configv1.PowerVSPlatformStatus{Region: "us-south"},
+			},
+		},
+	}
+	validEndpoints := modifier(basicObj, func(i *configv1.Infrastructure) {
+		i.Spec.PlatformSpec.PowerVS = &configv1.PowerVSPlatformSpec{
+			ServiceEndpoints: []configv1.PowerVSServiceEndpoint{
+				{
+					Name: "iam",
+					URL:  "https://iam.test.cloud.ibm.com",
+				},
+				{
+					Name: "pe",
+					URL:  "https://dal.power-iaas.test.cloud.ibm.com",
+				},
+			},
+		}
+	})
+	cases := []struct {
+		obj              *configv1.Infrastructure
+		expectedActions  int
+		expectedServices []configv1.PowerVSServiceEndpoint
+		expectedErr      string
+	}{
+		{
+			obj:              basicObj,
+			expectedActions:  0,
+			expectedServices: nil,
+			expectedErr:      "",
+		}, {
+			obj: modifier(basicObj, func(i *configv1.Infrastructure) {
+				i.ObjectMeta.Name = "something else"
+			}),
+			expectedActions:  0,
+			expectedServices: nil,
+			expectedErr:      "",
+		}, {
+			obj: modifier(basicObj, func(i *configv1.Infrastructure) {
+				i.Spec.PlatformSpec.Type = configv1.NonePlatformType
+			}),
+			expectedActions:  0,
+			expectedServices: nil,
+			expectedErr:      `spec\.platformSpec\.type: Invalid value: "None": non Power VS platform type set in specification`,
+		}, {
+			obj: modifier(basicObj, func(i *configv1.Infrastructure) {
+				i.Spec.PlatformSpec.PowerVS = &configv1.PowerVSPlatformSpec{}
+			}),
+			expectedActions:  0,
+			expectedServices: nil,
+			expectedErr:      "",
+		}, {
+			obj: modifier(basicObj, func(i *configv1.Infrastructure) {
+				i.Status.PlatformStatus = nil
+			}),
+			expectedActions:  0,
+			expectedServices: nil,
+			expectedErr:      "",
+		}, {
+			obj: modifier(basicObj, func(i *configv1.Infrastructure) {
+				i.Status.PlatformStatus.Type = configv1.NonePlatformType
+			}),
+			expectedActions:  0,
+			expectedServices: nil,
+			expectedErr:      "",
+		}, {
+			obj:              validEndpoints,
+			expectedActions:  1,
+			expectedServices: []configv1.PowerVSServiceEndpoint{{Name: "iam", URL: "https://iam.test.cloud.ibm.com"}, {Name: "pe", URL: "https://dal.power-iaas.test.cloud.ibm.com"}},
+			expectedErr:      "",
+		}, {
+			obj: modifier(validEndpoints, func(i *configv1.Infrastructure) {
+				sort.Slice(i.Spec.PlatformSpec.PowerVS.ServiceEndpoints, func(x, y int) bool {
+					return i.Spec.PlatformSpec.PowerVS.ServiceEndpoints[x].Name > i.Spec.PlatformSpec.PowerVS.ServiceEndpoints[y].Name
+				})
+			}),
+			expectedActions:  1,
+			expectedServices: []configv1.PowerVSServiceEndpoint{{Name: "iam", URL: "https://iam.test.cloud.ibm.com"}, {Name: "pe", URL: "https://dal.power-iaas.test.cloud.ibm.com"}},
+			expectedErr:      "",
+		}, {
+			obj: modifier(validEndpoints, func(i *configv1.Infrastructure) {
+				i.Spec.PlatformSpec.PowerVS.ServiceEndpoints = append(i.Spec.PlatformSpec.PowerVS.ServiceEndpoints, configv1.PowerVSServiceEndpoint{Name: "rc", URL: "https://resource-controller.test.cloud.ibm.com/something"})
+			}),
+			expectedActions:  0,
+			expectedServices: nil,
+			expectedErr:      `^spec\.platformSpec\.powervs.serviceEndpoints\[2\]\.url: Invalid value: "https://resource-controller.test.cloud.ibm.com/something": no path or request parameters must be provided, "/something" was provided$`,
+		}, {
+			obj: modifier(validEndpoints, func(i *configv1.Infrastructure) {
+				i.Spec.PlatformSpec.PowerVS.ServiceEndpoints = append(i.Spec.PlatformSpec.PowerVS.ServiceEndpoints, configv1.PowerVSServiceEndpoint{Name: "iam", URL: "https://iam.test.cloud.ibm.com"})
+			}),
+			expectedActions:  0,
+			expectedServices: nil,
+			expectedErr:      `^spec\.platformSpec\.powervs\.serviceEndpoints\[2\]\.name: Invalid value: "iam": duplicate service endpoint not allowed for iam, service endpoint already defined at spec\.platformSpec\.powervs\.serviceEndpoints\[0\]$`,
+		}, {
+			obj: modifier(validEndpoints, func(i *configv1.Infrastructure) {
+				i.Status.PlatformStatus.PowerVS.ServiceEndpoints = i.Spec.PlatformSpec.PowerVS.ServiceEndpoints
+			}),
+			expectedActions:  0,
+			expectedServices: []configv1.PowerVSServiceEndpoint{{Name: "iam", URL: "https://iam.test.cloud.ibm.com"}, {Name: "pe", URL: "https://dal.power-iaas.test.cloud.ibm.com"}},
+			expectedErr:      "",
+		}, {
+			obj: modifier(validEndpoints, func(i *configv1.Infrastructure) {
+				i.Status.PlatformStatus.PowerVS.ServiceEndpoints = i.Spec.PlatformSpec.PowerVS.ServiceEndpoints
+				i.Spec.PlatformSpec.PowerVS.ServiceEndpoints = append(i.Spec.PlatformSpec.PowerVS.ServiceEndpoints, configv1.PowerVSServiceEndpoint{Name: "rc", URL: "https://resource-controller.test.cloud.ibm.com/something"})
+			}),
+			expectedActions:  0,
+			expectedServices: []configv1.PowerVSServiceEndpoint{{Name: "iam", URL: "https://iam.test.cloud.ibm.com"}, {Name: "pe", URL: "https://dal.power-iaas.test.cloud.ibm.com"}},
+			expectedErr:      `^spec\.platformSpec\.powervs.serviceEndpoints\[2\]\.url: Invalid value: "https://resource-controller.test.cloud.ibm.com/something": no path or request parameters must be provided, "/something" was provided$`,
+		}, {
+			obj: modifier(validEndpoints, func(i *configv1.Infrastructure) {
+				i.Status.PlatformStatus.PowerVS.ServiceEndpoints = i.Spec.PlatformSpec.PowerVS.ServiceEndpoints
+				i.Spec.PlatformSpec.PowerVS.ServiceEndpoints = append(i.Spec.PlatformSpec.PowerVS.ServiceEndpoints, configv1.PowerVSServiceEndpoint{Name: "iam", URL: "https://iam.test.cloud.ibm.com"})
+			}),
+			expectedActions:  0,
+			expectedServices: []configv1.PowerVSServiceEndpoint{{Name: "iam", URL: "https://iam.test.cloud.ibm.com"}, {Name: "pe", URL: "https://dal.power-iaas.test.cloud.ibm.com"}},
+			expectedErr:      `^spec\.platformSpec\.powervs\.serviceEndpoints\[2\]\.name: Invalid value: "iam": duplicate service endpoint not allowed for iam, service endpoint already defined at spec\.platformSpec\.powervs\.serviceEndpoints\[0\]$`,
+		}, {
+			obj: modifier(validEndpoints, func(i *configv1.Infrastructure) {
+				i.Status.PlatformStatus.PowerVS.ServiceEndpoints = []configv1.PowerVSServiceEndpoint{{Name: "iam", URL: "https://iam.test.cloud.ibm.com"}}
+				i.Spec.PlatformSpec.PowerVS.ServiceEndpoints = nil
+			}),
+			expectedActions:  1,
+			expectedServices: nil,
+			expectedErr:      ``,
+		}, {
+			obj: modifier(validEndpoints, func(i *configv1.Infrastructure) {
+				i.Status.PlatformStatus.PowerVS.ServiceEndpoints = []configv1.PowerVSServiceEndpoint{{Name: "iam", URL: "https://iam.test.cloud.ibm.com"}}
+				i.Spec.PlatformSpec.PowerVS.ServiceEndpoints = []configv1.PowerVSServiceEndpoint{}
+			}),
+			expectedActions:  1,
+			expectedServices: nil,
+			expectedErr:      ``,
+		}, {
+			obj: modifier(validEndpoints, func(i *configv1.Infrastructure) {
+				i.Status.PlatformStatus.PowerVS.ServiceEndpoints = []configv1.PowerVSServiceEndpoint{{Name: "iam", URL: "https://iam.test.cloud.ibm.com"}}
+				i.Spec.PlatformSpec.PowerVS = nil
+			}),
+			expectedActions:  1,
+			expectedServices: nil,
+			expectedErr:      ``,
+		}}
+	for _, tc := range cases {
+		t.Run("test_sync", func(t *testing.T) {
+			indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{})
+			if err := indexer.Add(tc.obj); err != nil {
+				t.Fatal(err.Error())
+			}
+			fake := configfakeclient.NewSimpleClientset(tc.obj)
+			ctrl := PowerVSPlatformCustomServiceController{
+				infraClient: fake.ConfigV1().Infrastructures(),
+				infraLister: configv1listers.NewInfrastructureLister(indexer),
+			}
+
+			err := ctrl.sync(context.TODO(),
+				factory.NewSyncContext("PowerVSPlatformCustomServiceController", events.NewInMemoryRecorder("PowerVSPlatformCustomServiceController")))
+			if tc.expectedErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Regexp(t, tc.expectedErr, err.Error())
+			}
+
+			assert.Equal(t, tc.expectedActions, len(fake.Actions()))
+
+			var services []configv1.PowerVSServiceEndpoint
+			if tc.obj.Status.PlatformStatus != nil && tc.obj.Status.PlatformStatus.PowerVS != nil {
+				services = tc.obj.Status.PlatformStatus.PowerVS.ServiceEndpoints
+			}
+			for _, a := range fake.Actions() {
+				obj := a.(ktesting.UpdateAction).GetObject().(*configv1.Infrastructure)
+				if obj.Status.PlatformStatus != nil && obj.Status.PlatformStatus.PowerVS != nil {
+					services = obj.Status.PlatformStatus.PowerVS.ServiceEndpoints
+				}
+			}
+			assert.EqualValues(t, tc.expectedServices, services)
+		})
+	}
+}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -26,6 +26,7 @@ import (
 	kubecloudconfig "github.com/openshift/cluster-config-operator/pkg/operator/kube_cloud_config"
 	"github.com/openshift/cluster-config-operator/pkg/operator/migration_platform_status"
 	"github.com/openshift/cluster-config-operator/pkg/operator/operatorclient"
+	"github.com/openshift/cluster-config-operator/pkg/operator/powervs_platform_custom_service"
 )
 
 func RunOperator(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {
@@ -52,6 +53,14 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	}
 
 	infraController := aws_platform_service_location.NewController(
+		operatorClient,
+		configClient.ConfigV1(),
+		configInformers.Config().V1().Infrastructures().Lister(),
+		configInformers.Config().V1().Infrastructures().Informer(),
+		controllerContext.EventRecorder,
+	)
+
+	powervsCustomServiceController := powervs_platform_custom_service.NewController(
 		operatorClient,
 		configClient.ConfigV1(),
 		configInformers.Config().V1().Infrastructures().Lister(),
@@ -147,6 +156,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	go kubeInformersForNamespaces.Start(ctx.Done())
 
 	go infraController.Run(ctx, 1)
+	go powervsCustomServiceController.Run(ctx, 1)
 	go kubeCloudConfigController.Run(ctx, 1)
 	go logLevelController.Run(ctx, 1)
 	go statusController.Run(ctx, 1)


### PR DESCRIPTION
This PR  contains the changes to add a Power VS CustomServiceController which will sync the CustomServiceEndpoints from Spec field of infrastructure object to status field of infrastructure object after doing some validation.

openshift/api PR to add ServiceEndpoints: https://github.com/openshift/api/pull/1025


