### PR TITLE
Add client certificate and key to service monitor

### DIFF
--- a/manifests/0000_30_config-operator_03_servicemonitor.yaml
+++ b/manifests/0000_30_config-operator_03_servicemonitor.yaml
@@ -16,6 +16,8 @@ spec:
     tlsConfig:
       caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
       serverName: metrics.openshift-config-operator.svc
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
   jobLabel: component
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
Added client certificates based on https://github.com/deads2k/openshift-enhancements/blob/master/enhancements/monitoring/client-cert-scraping.md