### PR TITLE
This is not the repo you're looking for.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # cluster-config-operator
+
+This repo is not open for control loop contributions.
+This repo only exists to hold the CRD manifests required to bootstrap a cluster, it is not a place to add logic because jointly owned repos
+like this one end up having no owner to handle migration over time as dependencies move.
+
 The canonical location for OpenShift cluster configuration. This repo includes:
  1. The source of all CRD manifests for config.openshift.io
  2. A render command which creates the initial CRs for all config.openshift.io resource.
- 3. Future: An operator that handles migration needs as config.openshift.io is expanded.
+


### PR DESCRIPTION
This repo has no owner.  We should not add additional code here.

Ultimately, most of the "one time migration code" actually lives for quite a while and deserves a home more closely associated with what it does.  Remember that our config.openshift.io resources are based on how cluster-admins associate them, not based on the operators (often plural) that actually handle the information.  This means that we can easily end up in situations where individual fields of the same resources are set by different operators.