### PR TITLE
Increase verbosity level to track probe timeouts

### DIFF
--- a/manifests/0000_30_config-operator_01_operator.cr.yaml
+++ b/manifests/0000_30_config-operator_01_operator.cr.yaml
@@ -9,3 +9,4 @@ metadata:
     release.openshift.io/create-only: "true"
 spec:
   managementState: Managed
+  operatorLogLevel: Debug


### PR DESCRIPTION
Related to [TRT-567](https://issues.redhat.com//browse/TRT-567)

Blocker Jira to remove this [TRT-570](https://issues.redhat.com/browse/TRT-570)

We'd like to turn on more verbose logging to track readiness probe errors that get timeouts.  We consider this temporary and intend to remove this once we get enough data.