### PR TITLE
Require consistency in rendered artifacts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/openshift/api v0.0.0-20230426193520-54a14470e5dc
 	github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
 	github.com/openshift/client-go v0.0.0-20230120202327-72f107311084
-	github.com/openshift/library-go v0.0.0-20230427133628-add9892da47e
+	github.com/openshift/library-go v0.0.0-20230502125217-e45be8351afe
 	github.com/spf13/cobra v1.6.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -418,8 +418,8 @@ github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR
 github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20230120202327-72f107311084 h1:66uaqNwA+qYyQDwsMWUfjjau8ezmg1dzCqub13KZOcE=
 github.com/openshift/client-go v0.0.0-20230120202327-72f107311084/go.mod h1:M3h9m001PWac3eAudGG3isUud6yBjr5XpzLYLLTlHKo=
-github.com/openshift/library-go v0.0.0-20230427133628-add9892da47e h1:GFyfPd8IsGfsVANMM+WtNxmy0XBvvXF2Ie7Duzjbui0=
-github.com/openshift/library-go v0.0.0-20230427133628-add9892da47e/go.mod h1:JLv17uWyQvoK14yxp7h2vBJ8zz2xkWqanOv5TzuFkvY=
+github.com/openshift/library-go v0.0.0-20230502125217-e45be8351afe h1:vD0AgG+SQdktMtRKAfrGc91Ib5AJbGqnAfFFYzArAdY=
+github.com/openshift/library-go v0.0.0-20230502125217-e45be8351afe/go.mod h1:JLv17uWyQvoK14yxp7h2vBJ8zz2xkWqanOv5TzuFkvY=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/featuregate.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/featuregate.go
@@ -1,0 +1,47 @@
+package featuregates
+
+import (
+	"fmt"
+	configv1 "github.com/openshift/api/config/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// FeatureGate indicates whether a given feature is enabled or not
+// This interface is heavily influenced by k8s.io/component-base, but not exactly compatible.
+type FeatureGate interface {
+	// Enabled returns true if the key is enabled.
+	Enabled(key configv1.FeatureGateName) bool
+	// KnownFeatures returns a slice of strings describing the FeatureGate's known features.
+	KnownFeatures() []configv1.FeatureGateName
+}
+
+type featureGate struct {
+	enabled  sets.Set[configv1.FeatureGateName]
+	disabled sets.Set[configv1.FeatureGateName]
+}
+
+func NewFeatureGate(enabled, disabled []configv1.FeatureGateName) FeatureGate {
+	return &featureGate{
+		enabled:  sets.New[configv1.FeatureGateName](enabled...),
+		disabled: sets.New[configv1.FeatureGateName](disabled...),
+	}
+}
+
+func (f *featureGate) Enabled(key configv1.FeatureGateName) bool {
+	if f.enabled.Has(key) {
+		return true
+	}
+	if f.disabled.Has(key) {
+		return false
+	}
+
+	panic(fmt.Errorf("feature %q is not registered in FeatureGates %v", key, f.KnownFeatures()))
+}
+
+func (f *featureGate) KnownFeatures() []configv1.FeatureGateName {
+	allKnown := sets.NewString()
+	allKnown.Insert(FeatureGateNamesToStrings(f.enabled.UnsortedList())...)
+	allKnown.Insert(FeatureGateNamesToStrings(f.disabled.UnsortedList())...)
+
+	return StringsToFeatureGateNames(allKnown.List())
+}

--- a/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/hardcoded_featuregate_reader.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/configobserver/featuregates/hardcoded_featuregate_reader.go
@@ -61,8 +61,8 @@ func (c *hardcodedFeatureGateAccess) AreInitialFeatureGatesObserved() bool {
 	}
 }
 
-func (c *hardcodedFeatureGateAccess) CurrentFeatureGates() ([]configv1.FeatureGateName, []configv1.FeatureGateName, error) {
-	return c.enabled, c.disabled, c.readErr
+func (c *hardcodedFeatureGateAccess) CurrentFeatureGates() (FeatureGate, error) {
+	return NewFeatureGate(c.enabled, c.disabled), c.readErr
 }
 
 // NewHardcodedFeatureGateAccessFromFeatureGate returns a FeatureGateAccess that is static and initialised from

--- a/vendor/github.com/openshift/library-go/pkg/operator/render/options/config.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/render/options/config.go
@@ -1,7 +1,16 @@
 package options
 
 import (
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+
 	"github.com/openshift/library-go/pkg/operator/resource/resourceread"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog/v2"
@@ -34,18 +43,15 @@ type ManifestConfig struct {
 	ImagePullPolicy string
 }
 
-// FileConfig
 type FileConfig struct {
 	// BootstrapConfig holds the rendered control plane component config file for bootstrapping (phase 1).
 	BootstrapConfig []byte
 
 	// Assets holds the loaded assets like certs and keys.
 	Assets map[string][]byte
-
-	// RenderedManifests are the files, content, and (optionally) decoded objects that were passed to the command
-	// as already present to be created by cluster-bootstrap.
-	RenderedManifests []RenderedManifest
 }
+
+type RenderedManifests []RenderedManifest
 
 type RenderedManifest struct {
 	OriginalFilename string
@@ -60,20 +66,139 @@ type TemplateData struct {
 	FileConfig
 }
 
-func (c *FileConfig) ListManifestOfType(gvk schema.GroupVersionKind) []RenderedManifest {
+func (renderedManifests RenderedManifests) ListManifestOfType(gvk schema.GroupVersionKind) []RenderedManifest {
 	ret := []RenderedManifest{}
-	for i := range c.RenderedManifests {
-		obj, err := c.RenderedManifests[i].GetDecodedObj()
+	for i := range renderedManifests {
+		obj, err := renderedManifests[i].GetDecodedObj()
 		if err != nil {
-			klog.Warningf("failure to read %q: %v", c.RenderedManifests[i].OriginalFilename, err)
+			klog.Warningf("failure to read %q: %v", renderedManifests[i].OriginalFilename, err)
 			continue
 		}
 		if obj.GetObjectKind().GroupVersionKind() == gvk {
-			ret = append(ret, c.RenderedManifests[i])
+			ret = append(ret, renderedManifests[i])
 		}
 	}
 
 	return ret
+}
+
+func (renderedManifests RenderedManifests) GetManifest(gvk schema.GroupVersionKind, namespace, name string) (RenderedManifest, error) {
+	for i := range renderedManifests {
+		obj, err := renderedManifests[i].GetDecodedObj()
+		if err != nil {
+			klog.Warningf("failure to read %q: %v", renderedManifests[i].OriginalFilename, err)
+			continue
+		}
+		if obj.GetObjectKind().GroupVersionKind() != gvk {
+			continue
+		}
+		objMetadata, err := meta.Accessor(obj)
+		if err != nil {
+			klog.Warningf("failure to read metadata %q: %v", renderedManifests[i].OriginalFilename, err)
+			continue
+		}
+
+		// since validation requires that all of these are the same, it doesn't matterwhich one we return
+		if objMetadata.GetName() == name && objMetadata.GetNamespace() == namespace {
+			return renderedManifests[i], nil
+		}
+	}
+
+	return RenderedManifest{}, apierrors.NewNotFound(
+		schema.GroupResource{
+			Group:    gvk.Group,
+			Resource: gvk.Kind,
+		},
+		name)
+}
+
+func (renderedManifests RenderedManifests) GetObject(gvk schema.GroupVersionKind, namespace, name string) (runtime.Object, error) {
+	manifest, err := renderedManifests.GetManifest(gvk, namespace, name)
+	if err != nil {
+		return nil, err
+	}
+	return manifest.decodedObj, nil
+}
+
+func (renderedManifests RenderedManifests) ValidateManifestPredictability() error {
+	errs := []error{}
+	decodeErrorsObserved := map[int]bool{}
+	metadataErrorsObserved := map[int]bool{}
+
+	type compareTuple struct {
+		i, j int
+	}
+	compareTuplesErrorsObserved := map[compareTuple]bool{}
+
+	for i := range renderedManifests {
+		lhs := renderedManifests[i]
+		lhsObj, err := lhs.GetDecodedObj()
+		if err != nil {
+			if !decodeErrorsObserved[i] {
+				errs = append(errs, err)
+				decodeErrorsObserved[i] = true
+			}
+			continue
+		}
+		lhsMetadata, err := meta.Accessor(lhsObj)
+		if err != nil {
+			if !metadataErrorsObserved[i] {
+				errs = append(errs, fmt.Errorf("unable to read metadata for %q: %w", lhs.OriginalFilename, err))
+				metadataErrorsObserved[i] = true
+			}
+			continue
+		}
+
+		for j := range renderedManifests {
+			if i == j {
+				continue
+			}
+			rhs := renderedManifests[j]
+			rhsObj, err := rhs.GetDecodedObj()
+			if err != nil {
+				if !decodeErrorsObserved[j] {
+					errs = append(errs, err)
+					decodeErrorsObserved[j] = true
+				}
+				continue
+			}
+			rhsMetadata, err := meta.Accessor(rhsObj)
+			if err != nil {
+				if !metadataErrorsObserved[j] {
+					errs = append(errs, fmt.Errorf("unable to read metadata for %q: %w", rhs.OriginalFilename, err))
+					metadataErrorsObserved[j] = true
+				}
+				continue
+			}
+			if lhsObj.GetObjectKind().GroupVersionKind().GroupKind() != rhsObj.GetObjectKind().GroupVersionKind().GroupKind() {
+				continue
+			}
+			if lhsMetadata.GetName() != rhsMetadata.GetName() {
+				continue
+			}
+			if lhsMetadata.GetNamespace() != rhsMetadata.GetNamespace() {
+				continue
+			}
+
+			if !equality.Semantic.DeepEqual(lhsObj, rhsObj) {
+				if !compareTuplesErrorsObserved[compareTuple{i, j}] {
+					errs = append(errs,
+						fmt.Errorf("%q and %q both set %v.%v/%v in ns/%v, but have different values",
+							lhs.OriginalFilename,
+							rhs.OriginalFilename,
+							lhsObj.GetObjectKind().GroupVersionKind().Kind,
+							lhsObj.GetObjectKind().GroupVersionKind().Group,
+							lhsMetadata.GetName(),
+							lhsMetadata.GetNamespace(),
+						))
+					compareTuplesErrorsObserved[compareTuple{i, j}] = true
+					compareTuplesErrorsObserved[compareTuple{j, i}] = true
+				}
+			}
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
 }
 
 func (c *RenderedManifest) GetDecodedObj() (runtime.Object, error) {
@@ -82,7 +207,7 @@ func (c *RenderedManifest) GetDecodedObj() (runtime.Object, error) {
 	}
 	obj, err := resourceread.ReadGenericWithUnstructured(c.Content)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to decode %q: %w", c.OriginalFilename, err)
 	}
 	c.decodedObj = obj
 

--- a/vendor/github.com/openshift/library-go/pkg/operator/render/options/generic.go
+++ b/vendor/github.com/openshift/library-go/pkg/operator/render/options/generic.go
@@ -5,17 +5,16 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"text/template"
 
 	"github.com/ghodss/yaml"
-	"github.com/spf13/pflag"
-
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	configv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/library-go/pkg/assets"
+	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // GenericOptions contains the generic render command options.
@@ -31,7 +30,8 @@ type GenericOptions struct {
 	AssetInputDir  string
 	AssetOutputDir string
 
-	FeatureSet string
+	FeatureSet     string
+	PayloadVersion string
 }
 
 type Template struct {
@@ -57,6 +57,8 @@ func (o *GenericOptions) AddFlags(fs *pflag.FlagSet, configGVK schema.GroupVersi
 	fs.StringVar(&o.FeatureSet, "feature-set", o.FeatureSet, "Enables features that are not part of the default feature set.")
 	fs.StringSliceVar(&o.RenderedManifestInputFilenames, "rendered-manifest-files", o.RenderedManifestInputFilenames,
 		"files or directories containing yaml or json manifests that will be created via cluster-bootstrapping.")
+	fs.StringVar(&o.PayloadVersion, "payload-version", o.PayloadVersion, "Version that will eventually be placed into ClusterOperator.status.  This normally comes from the CVO set via env var: OPERATOR_IMAGE_VERSION.")
+
 }
 
 type gvkOutput struct {
@@ -87,10 +89,11 @@ func (o *GenericOptions) Validate() error {
 		return errors.New("missing required flag: --config-output-file")
 	}
 
-	for _, filename := range o.RenderedManifestInputFilenames {
-		_, err := os.Stat(filename)
-		if err != nil {
-			return fmt.Errorf("--rendered-manifest-files, value %q could not be read: %v", filename, err)
+	if renderedManifests, err := o.ReadInputManifests(); err != nil {
+		return fmt.Errorf("--rendered-manifest-files, could not be read: %v", err)
+	} else {
+		if err := renderedManifests.ValidateManifestPredictability(); err != nil {
+			return fmt.Errorf("--rendered-manifest-files, are not consistent so results would be unpredictable depending on apply order: %v", err)
 		}
 	}
 
@@ -99,7 +102,73 @@ func (o *GenericOptions) Validate() error {
 	default:
 		return fmt.Errorf("invalid feature-set specified: %q", o.FeatureSet)
 	}
+
 	return nil
+}
+
+func (o *GenericOptions) ReadInputManifests() (RenderedManifests, error) {
+	ret := RenderedManifests{}
+	for _, filename := range o.RenderedManifestInputFilenames {
+		manifestContent, err := assets.LoadFilesRecursively(filename)
+		if err != nil {
+			return nil, fmt.Errorf("failed loading rendered manifest inputs from %q: %w", filename, err)
+		}
+		for manifestFile, content := range manifestContent {
+			ret = append(ret, RenderedManifest{
+				OriginalFilename: manifestFile,
+				Content:          content,
+			})
+		}
+	}
+
+	return ret, nil
+}
+
+func (o *GenericOptions) FeatureGates() (featuregates.FeatureGateAccess, error) {
+	if len(o.PayloadVersion) == 0 {
+		return nil, fmt.Errorf("cannot return FeatureGate without payload version")
+	}
+	if len(o.RenderedManifestInputFilenames) == 0 {
+		return nil, fmt.Errorf("cannot return FeatureGate without rendered manifests")
+	}
+
+	inputManifest, err := o.ReadInputManifests()
+	if err != nil {
+		return nil, fmt.Errorf("error reading input manifests: %w", err)
+	}
+	featureGates := inputManifest.ListManifestOfType(configv1.GroupVersion.WithKind("FeatureGate"))
+	if len(featureGates) == 0 {
+		return nil, fmt.Errorf("no FeatureGates found in manfest dir: %v", o.RenderedManifestInputFilenames)
+	}
+	var prev *RenderedManifest
+	var featureGate *configv1.FeatureGate
+	for i := range featureGates {
+		curr := featureGates[i]
+		decodedObj, err := curr.GetDecodedObj()
+		if err != nil {
+			return nil, fmt.Errorf("decoding failure for %q: %w", curr.OriginalFilename, err)
+		}
+		currFeatureGate, ok := decodedObj.(*configv1.FeatureGate)
+		if !ok {
+			return nil, fmt.Errorf("wrong obj type for %q: %T: %v", curr.OriginalFilename, decodedObj, curr.Content)
+		}
+		if featureGate == nil {
+			prev = &curr
+			featureGate = currFeatureGate
+			continue
+		}
+
+		if !equality.Semantic.DeepEqual(featureGate, currFeatureGate) {
+			return nil, fmt.Errorf("FeatureGate manifests disagree: %q and %q, with \n%v\n%v ", prev.OriginalFilename, curr.OriginalFilename, prev.Content, curr.Content)
+		}
+	}
+
+	ret, err := featuregates.NewHardcodedFeatureGateAccessFromFeatureGate(featureGate, o.PayloadVersion)
+	if err != nil {
+		return nil, fmt.Errorf("error creating feature accessor: %w", err)
+	}
+
+	return ret, nil
 }
 
 // ApplyTo applies the options to the given config struct using the provided text/template data.
@@ -114,19 +183,6 @@ func (o *GenericOptions) ApplyTo(cfg *FileConfig, defaultConfig, bootstrapOverri
 	// load and render templates
 	if cfg.Assets, err = assets.LoadFilesRecursively(o.AssetInputDir); err != nil {
 		return fmt.Errorf("failed loading assets from %q: %v", o.AssetInputDir, err)
-	}
-
-	for _, filename := range o.RenderedManifestInputFilenames {
-		manifestContent, err := assets.LoadFilesRecursively(filename)
-		if err != nil {
-			return fmt.Errorf("failed loading rendered manifest inputs from %q: %w", filename, err)
-		}
-		for manifestFile, content := range manifestContent {
-			cfg.RenderedManifests = append(cfg.RenderedManifests, RenderedManifest{
-				OriginalFilename: manifestFile,
-				Content:          content,
-			})
-		}
 	}
 
 	return nil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -257,7 +257,7 @@ github.com/openshift/client-go/config/informers/externalversions/config/v1alpha1
 github.com/openshift/client-go/config/informers/externalversions/internalinterfaces
 github.com/openshift/client-go/config/listers/config/v1
 github.com/openshift/client-go/config/listers/config/v1alpha1
-# github.com/openshift/library-go v0.0.0-20230427133628-add9892da47e
+# github.com/openshift/library-go v0.0.0-20230502125217-e45be8351afe
 ## explicit; go 1.19
 github.com/openshift/library-go/pkg/assets
 github.com/openshift/library-go/pkg/authorization/hardcodedauthorizer


### PR DESCRIPTION
adds a check for those consuming rendered manifests that none of the contents conflict.  Conflicts would result in unpredictable results on the cluster.