### PR TITLE
Add JoelSpeed to owners

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,10 +4,12 @@ reviewers:
   - sttts
   - soltysh
   - tkashem
+  - JoelSpeed
 approvers:
   - deads2k
   - mfojtik
   - sttts
   - soltysh
   - tkashem
+  - JoelSpeed
 component: config-operator


### PR DESCRIPTION
To enable smoother integration of feature gates, we need to have approvers who can approve dependency bumps so that the config operator is always up to date with the latest feature gate state from openshift/api