### PR TITLE
stomp the latencysensitive featureset for equivalent default

### DIFF
--- a/pkg/operator/removelatencysensitive/OWNERS
+++ b/pkg/operator/removelatencysensitive/OWNERS
@@ -1,0 +1,9 @@
+# https://github.com/openshift/installer/blob/75738a342c1973121eedda7d91096d21c19194c9/OWNERS_ALIASES#L47-L50
+
+reviewers:
+- deads2k
+- joelspeed
+approvers:
+# these are the api-approvers from openshift/api
+- deads2k
+- joelspeed

--- a/pkg/operator/removelatencysensitive/removelatencysensitive_controller.go
+++ b/pkg/operator/removelatencysensitive/removelatencysensitive_controller.go
@@ -1,0 +1,76 @@
+package removelatencysensitive
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	applyconfigurationsconfigv1 "github.com/openshift/client-go/config/applyconfigurations/config/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	v1 "github.com/openshift/client-go/config/informers/externalversions/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// LatencySensitiveRemovalController clears the LatencySensitive featuregate value
+type LatencySensitiveRemovalController struct {
+	featureGatesClient configv1client.FeatureGatesGetter
+	featureGatesLister configlistersv1.FeatureGateLister
+
+	eventRecorder events.Recorder
+}
+
+func NewLatencySensitiveRemovalController(operatorClient operatorv1helpers.OperatorClient,
+	featureGatesClient configv1client.FeatureGatesGetter, featureGatesInformer v1.FeatureGateInformer,
+	eventRecorder events.Recorder) factory.Controller {
+	c := &LatencySensitiveRemovalController{
+		featureGatesClient: featureGatesClient,
+		featureGatesLister: featureGatesInformer.Lister(),
+		eventRecorder:      eventRecorder,
+	}
+
+	return factory.New().
+		WithSync(c.sync).
+		WithSyncDegradedOnError(operatorClient).
+		ResyncEvery(time.Minute).
+		ToController("LatencySensitiveRemovalController", eventRecorder)
+}
+
+func (c LatencySensitiveRemovalController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	featureGates, err := c.featureGatesLister.Get("cluster")
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("unable to get FeatureGate: %w", err)
+	}
+
+	return c.syncFeatureGate(ctx, featureGates)
+}
+
+func (c LatencySensitiveRemovalController) syncFeatureGate(ctx context.Context, featureGates *configv1.FeatureGate) error {
+	if featureGates.Spec.FeatureSet != "LatencySensitive" {
+		return nil
+	}
+
+	desiredFeatureGate := applyconfigurationsconfigv1.FeatureGate("cluster").
+		WithSpec(
+			applyconfigurationsconfigv1.FeatureGateSpec().
+				WithFeatureSet(configv1.Default),
+		)
+	applyOptions := metav1.ApplyOptions{
+		Force:        true,
+		FieldManager: "LatencySensitiveRemovalController",
+	}
+
+	if _, err := c.featureGatesClient.FeatureGates().Apply(ctx, desiredFeatureGate, applyOptions); err != nil {
+		return fmt.Errorf("unable to remove LatencySensitive: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/operator/removelatencysensitive/removelatencysensitive_controller_test.go
+++ b/pkg/operator/removelatencysensitive/removelatencysensitive_controller_test.go
@@ -1,0 +1,97 @@
+package removelatencysensitive
+
+import (
+	"context"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configv1fake "github.com/openshift/client-go/config/clientset/versioned/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	kubetesting "k8s.io/client-go/testing"
+)
+
+func TestFeatureGateController_syncFeatureGate(t *testing.T) {
+	tests := []struct {
+		name        string
+		featureGate *configv1.FeatureGate
+
+		changeVerifier func(t *testing.T, actions []kubetesting.Action)
+	}{
+		{
+			name: "clear-value",
+			featureGate: &configv1.FeatureGate{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.FeatureGateSpec{
+					FeatureGateSelection: configv1.FeatureGateSelection{
+						FeatureSet: "LatencySensitive",
+					},
+				},
+			},
+			changeVerifier: func(t *testing.T, actions []kubetesting.Action) {
+				if len(actions) != 1 {
+					t.Fatalf("bad changes: %v", actions)
+				}
+				patchAction := actions[0].(kubetesting.PatchAction)
+				if patchAction.GetPatchType() != types.ApplyPatchType {
+					t.Fatalf("unexpected patch type: %v", patchAction.GetPatchType())
+				}
+				applied := string(patchAction.GetPatch())
+				expectedApplied := `{"kind":"FeatureGate","apiVersion":"config.openshift.io/v1","metadata":{"name":"cluster"},"spec":{"featureSet":""}}`
+				if applied != expectedApplied {
+					t.Fatal(applied)
+				}
+			},
+		},
+		{
+			name: "leave-other-value",
+			featureGate: &configv1.FeatureGate{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.FeatureGateSpec{
+					FeatureGateSelection: configv1.FeatureGateSelection{
+						FeatureSet: configv1.TechPreviewNoUpgrade,
+					},
+				},
+			},
+			changeVerifier: func(t *testing.T, actions []kubetesting.Action) {
+				if len(actions) != 0 {
+					t.Fatalf("bad changes: %v", actions)
+				}
+			},
+		},
+		{
+			name: "leave-desired-value",
+			featureGate: &configv1.FeatureGate{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.FeatureGateSpec{
+					FeatureGateSelection: configv1.FeatureGateSelection{
+						FeatureSet: configv1.Default,
+					},
+				},
+			},
+			changeVerifier: func(t *testing.T, actions []kubetesting.Action) {
+				if len(actions) != 0 {
+					t.Fatalf("bad changes: %v", actions)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			_, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			fakeClient := configv1fake.NewSimpleClientset(tt.featureGate)
+
+			c := LatencySensitiveRemovalController{
+				featureGatesClient: fakeClient.ConfigV1(),
+			}
+			if err := c.syncFeatureGate(ctx, tt.featureGate); err != nil {
+				t.Fatal(err)
+			}
+
+			tt.changeVerifier(t, fakeClient.Actions())
+		})
+	}
+}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -5,17 +5,17 @@ import (
 	"os"
 	"time"
 
-	"github.com/openshift/cluster-config-operator/pkg/operator/featuregates"
-
 	"github.com/davecgh/go-spew/spew"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions"
+	"github.com/openshift/cluster-config-operator/pkg/operator/aws_platform_service_location"
+	"github.com/openshift/cluster-config-operator/pkg/operator/featuregates"
+	kubecloudconfig "github.com/openshift/cluster-config-operator/pkg/operator/kube_cloud_config"
+	"github.com/openshift/cluster-config-operator/pkg/operator/migration_platform_status"
+	"github.com/openshift/cluster-config-operator/pkg/operator/operatorclient"
+	"github.com/openshift/cluster-config-operator/pkg/operator/removelatencysensitive"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/genericoperatorclient"
@@ -23,11 +23,9 @@ import (
 	"github.com/openshift/library-go/pkg/operator/staleconditions"
 	"github.com/openshift/library-go/pkg/operator/status"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
-
-	"github.com/openshift/cluster-config-operator/pkg/operator/aws_platform_service_location"
-	kubecloudconfig "github.com/openshift/cluster-config-operator/pkg/operator/kube_cloud_config"
-	"github.com/openshift/cluster-config-operator/pkg/operator/migration_platform_status"
-	"github.com/openshift/cluster-config-operator/pkg/operator/operatorclient"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 func RunOperator(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {
@@ -77,6 +75,14 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 		configInformers.Config().V1().FeatureGates(),
 		configInformers.Config().V1().ClusterVersions(),
 		versionRecorder,
+		controllerContext.EventRecorder,
+	)
+
+	// to be removed a release after we block upgrades
+	latencySensitiveRemover := removelatencysensitive.NewLatencySensitiveRemovalController(
+		operatorClient,
+		configClient.ConfigV1(),
+		configInformers.Config().V1().FeatureGates(),
 		controllerContext.EventRecorder,
 	)
 
@@ -172,6 +178,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	go migrationPlatformStatusController.Run(ctx, 1)
 	go staleConditionsController.Run(ctx, 1)
 	go featureGateController.Run(ctx, 1)
+	go latencySensitiveRemover.Run(ctx, 1)
 
 	<-ctx.Done()
 	return nil


### PR DESCRIPTION
This let's us avoid dead-ending clusters.