### PR TITLE
OCPBUGS-15877: go upgradeable=false when latencysensitive is used and not corrected

### DIFF
--- a/pkg/operator/featureupgradablecontroller/OWNERS
+++ b/pkg/operator/featureupgradablecontroller/OWNERS
@@ -1,0 +1,9 @@
+# https://github.com/openshift/installer/blob/75738a342c1973121eedda7d91096d21c19194c9/OWNERS_ALIASES#L47-L50
+
+reviewers:
+- deads2k
+- joelspeed
+approvers:
+# these are the api-approvers from openshift/api
+- deads2k
+- joelspeed

--- a/pkg/operator/featureupgradablecontroller/feature_upgradeable_controller.go
+++ b/pkg/operator/featureupgradablecontroller/feature_upgradeable_controller.go
@@ -1,0 +1,73 @@
+package featureupgradablecontroller
+
+import (
+	"context"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configinformers "github.com/openshift/client-go/config/informers/externalversions"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var (
+	featureGatesAllowingUpgrade = sets.NewString("")
+)
+
+// FeatureUpgradeableController is a controller that sets upgradeable=false if anything outside the allowed list is the specified featuregates.
+type FeatureUpgradeableController struct {
+	operatorClient    v1helpers.OperatorClient
+	featureGateLister configlistersv1.FeatureGateLister
+}
+
+func NewFeatureUpgradeableController(
+	operatorClient v1helpers.OperatorClient,
+	configInformer configinformers.SharedInformerFactory,
+	eventRecorder events.Recorder,
+) factory.Controller {
+	c := &FeatureUpgradeableController{
+		operatorClient:    operatorClient,
+		featureGateLister: configInformer.Config().V1().FeatureGates().Lister(),
+	}
+
+	return factory.New().WithInformers(
+		operatorClient.Informer(),
+		configInformer.Config().V1().FeatureGates().Informer(),
+	).WithSync(c.sync).ToController("FeatureUpgradeableController", eventRecorder.WithComponentSuffix("feature-upgradeable"))
+}
+
+func (c *FeatureUpgradeableController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	featureGates, err := c.featureGateLister.Get("cluster")
+	if err != nil {
+		return err
+	}
+
+	cond := newUpgradeableCondition(featureGates)
+	if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+		return updateError
+	}
+
+	return nil
+}
+
+func newUpgradeableCondition(featureGates *configv1.FeatureGate) operatorv1.OperatorCondition {
+	if featureGatesAllowingUpgrade.Has(string(featureGates.Spec.FeatureSet)) {
+		return operatorv1.OperatorCondition{
+			Type:   "FeatureGatesUpgradeable",
+			Reason: "AllowedFeatureGates_" + string(featureGates.Spec.FeatureSet),
+			Status: operatorv1.ConditionTrue,
+		}
+	}
+
+	return operatorv1.OperatorCondition{
+		Type:    "FeatureGatesUpgradeable",
+		Status:  operatorv1.ConditionFalse,
+		Reason:  "RestrictedFeatureGates_" + string(featureGates.Spec.FeatureSet),
+		Message: fmt.Sprintf("%q does not allow updates", string(featureGates.Spec.FeatureSet)),
+	}
+
+}

--- a/pkg/operator/featureupgradablecontroller/feature_upgradeable_controller_test.go
+++ b/pkg/operator/featureupgradablecontroller/feature_upgradeable_controller_test.go
@@ -1,0 +1,75 @@
+package featureupgradablecontroller
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+)
+
+func TestNewUpgradeableCondition(t *testing.T) {
+	tests := []struct {
+		name string
+
+		features string
+		expected operatorv1.OperatorCondition
+	}{
+		{
+			name:     "default",
+			features: "",
+			expected: operatorv1.OperatorCondition{
+				Reason: "AllowedFeatureGates_",
+				Status: "True",
+				Type:   "FeatureGatesUpgradeable",
+			},
+		},
+		{
+			name:     "unknown",
+			features: "other",
+			expected: operatorv1.OperatorCondition{
+				Reason:  "RestrictedFeatureGates_other",
+				Status:  "False",
+				Type:    "FeatureGatesUpgradeable",
+				Message: "\"other\" does not allow updates",
+			},
+		},
+		{
+			name:     "techpreview",
+			features: string(configv1.TechPreviewNoUpgrade),
+			expected: operatorv1.OperatorCondition{
+				Reason:  "RestrictedFeatureGates_TechPreviewNoUpgrade",
+				Status:  "False",
+				Type:    "FeatureGatesUpgradeable",
+				Message: "\"TechPreviewNoUpgrade\" does not allow updates",
+			},
+		},
+		{
+			name:     "latencysensitive",
+			features: string(configv1.LatencySensitive),
+			expected: operatorv1.OperatorCondition{
+				Reason:  "RestrictedFeatureGates_LatencySensitive",
+				Status:  "False",
+				Type:    "FeatureGatesUpgradeable",
+				Message: "\"LatencySensitive\" does not allow updates",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := newUpgradeableCondition(&configv1.FeatureGate{
+				Spec: configv1.FeatureGateSpec{
+					FeatureGateSelection: configv1.FeatureGateSelection{
+						FeatureSet: configv1.FeatureSet(test.features),
+					},
+				},
+			})
+
+			if !reflect.DeepEqual(test.expected, actual) {
+				t.Fatal(spew.Sdump(actual))
+			}
+		})
+	}
+}


### PR DESCRIPTION
There are relatively few clusters even potentially impacted and we further limit that by automatically setting the equivalent featureset of "" in https://github.com/openshift/cluster-config-operator/pull/324 . This blocks upgrades if the value is not "".