### PR TITLE
OCPBUGS-16164: retire LatencySensitive featureset

### DIFF
--- a/pkg/operator/featureupgradablecontroller/OWNERS
+++ b/pkg/operator/featureupgradablecontroller/OWNERS
@@ -1,0 +1,9 @@
+# https://github.com/openshift/installer/blob/75738a342c1973121eedda7d91096d21c19194c9/OWNERS_ALIASES#L47-L50
+
+reviewers:
+- deads2k
+- joelspeed
+approvers:
+# these are the api-approvers from openshift/api
+- deads2k
+- joelspeed

--- a/pkg/operator/featureupgradablecontroller/feature_upgradeable_controller.go
+++ b/pkg/operator/featureupgradablecontroller/feature_upgradeable_controller.go
@@ -1,0 +1,73 @@
+package featureupgradablecontroller
+
+import (
+	"context"
+	"fmt"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	configinformers "github.com/openshift/client-go/config/informers/externalversions"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/v1helpers"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var (
+	featureGatesAllowingUpgrade = sets.NewString("")
+)
+
+// FeatureUpgradeableController is a controller that sets upgradeable=false if anything outside the allowed list is the specified featuregates.
+type FeatureUpgradeableController struct {
+	operatorClient    v1helpers.OperatorClient
+	featureGateLister configlistersv1.FeatureGateLister
+}
+
+func NewFeatureUpgradeableController(
+	operatorClient v1helpers.OperatorClient,
+	configInformer configinformers.SharedInformerFactory,
+	eventRecorder events.Recorder,
+) factory.Controller {
+	c := &FeatureUpgradeableController{
+		operatorClient:    operatorClient,
+		featureGateLister: configInformer.Config().V1().FeatureGates().Lister(),
+	}
+
+	return factory.New().WithInformers(
+		operatorClient.Informer(),
+		configInformer.Config().V1().FeatureGates().Informer(),
+	).WithSync(c.sync).ToController("FeatureUpgradeableController", eventRecorder.WithComponentSuffix("feature-upgradeable"))
+}
+
+func (c *FeatureUpgradeableController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	featureGates, err := c.featureGateLister.Get("cluster")
+	if err != nil {
+		return err
+	}
+
+	cond := newUpgradeableCondition(featureGates)
+	if _, _, updateError := v1helpers.UpdateStatus(ctx, c.operatorClient, v1helpers.UpdateConditionFn(cond)); updateError != nil {
+		return updateError
+	}
+
+	return nil
+}
+
+func newUpgradeableCondition(featureGates *configv1.FeatureGate) operatorv1.OperatorCondition {
+	if featureGatesAllowingUpgrade.Has(string(featureGates.Spec.FeatureSet)) {
+		return operatorv1.OperatorCondition{
+			Type:   "FeatureGatesUpgradeable",
+			Reason: "AllowedFeatureGates_" + string(featureGates.Spec.FeatureSet),
+			Status: operatorv1.ConditionTrue,
+		}
+	}
+
+	return operatorv1.OperatorCondition{
+		Type:    "FeatureGatesUpgradeable",
+		Status:  operatorv1.ConditionFalse,
+		Reason:  "RestrictedFeatureGates_" + string(featureGates.Spec.FeatureSet),
+		Message: fmt.Sprintf("%q does not allow updates", string(featureGates.Spec.FeatureSet)),
+	}
+
+}

--- a/pkg/operator/featureupgradablecontroller/feature_upgradeable_controller_test.go
+++ b/pkg/operator/featureupgradablecontroller/feature_upgradeable_controller_test.go
@@ -1,0 +1,75 @@
+package featureupgradablecontroller
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+)
+
+func TestNewUpgradeableCondition(t *testing.T) {
+	tests := []struct {
+		name string
+
+		features string
+		expected operatorv1.OperatorCondition
+	}{
+		{
+			name:     "default",
+			features: "",
+			expected: operatorv1.OperatorCondition{
+				Reason: "AllowedFeatureGates_",
+				Status: "True",
+				Type:   "FeatureGatesUpgradeable",
+			},
+		},
+		{
+			name:     "unknown",
+			features: "other",
+			expected: operatorv1.OperatorCondition{
+				Reason:  "RestrictedFeatureGates_other",
+				Status:  "False",
+				Type:    "FeatureGatesUpgradeable",
+				Message: "\"other\" does not allow updates",
+			},
+		},
+		{
+			name:     "techpreview",
+			features: string(configv1.TechPreviewNoUpgrade),
+			expected: operatorv1.OperatorCondition{
+				Reason:  "RestrictedFeatureGates_TechPreviewNoUpgrade",
+				Status:  "False",
+				Type:    "FeatureGatesUpgradeable",
+				Message: "\"TechPreviewNoUpgrade\" does not allow updates",
+			},
+		},
+		{
+			name:     "latencysensitive",
+			features: string(configv1.LatencySensitive),
+			expected: operatorv1.OperatorCondition{
+				Reason:  "RestrictedFeatureGates_LatencySensitive",
+				Status:  "False",
+				Type:    "FeatureGatesUpgradeable",
+				Message: "\"LatencySensitive\" does not allow updates",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := newUpgradeableCondition(&configv1.FeatureGate{
+				Spec: configv1.FeatureGateSpec{
+					FeatureGateSelection: configv1.FeatureGateSelection{
+						FeatureSet: configv1.FeatureSet(test.features),
+					},
+				},
+			})
+
+			if !reflect.DeepEqual(test.expected, actual) {
+				t.Fatal(spew.Sdump(actual))
+			}
+		})
+	}
+}

--- a/pkg/operator/removelatencysensitive/OWNERS
+++ b/pkg/operator/removelatencysensitive/OWNERS
@@ -1,0 +1,9 @@
+# https://github.com/openshift/installer/blob/75738a342c1973121eedda7d91096d21c19194c9/OWNERS_ALIASES#L47-L50
+
+reviewers:
+- deads2k
+- joelspeed
+approvers:
+# these are the api-approvers from openshift/api
+- deads2k
+- joelspeed

--- a/pkg/operator/removelatencysensitive/removelatencysensitive_controller.go
+++ b/pkg/operator/removelatencysensitive/removelatencysensitive_controller.go
@@ -1,0 +1,76 @@
+package removelatencysensitive
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	applyconfigurationsconfigv1 "github.com/openshift/client-go/config/applyconfigurations/config/v1"
+	configv1client "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	v1 "github.com/openshift/client-go/config/informers/externalversions/config/v1"
+	configlistersv1 "github.com/openshift/client-go/config/listers/config/v1"
+	"github.com/openshift/library-go/pkg/controller/factory"
+	"github.com/openshift/library-go/pkg/operator/events"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// LatencySensitiveRemovalController clears the LatencySensitive featuregate value
+type LatencySensitiveRemovalController struct {
+	featureGatesClient configv1client.FeatureGatesGetter
+	featureGatesLister configlistersv1.FeatureGateLister
+
+	eventRecorder events.Recorder
+}
+
+func NewLatencySensitiveRemovalController(operatorClient operatorv1helpers.OperatorClient,
+	featureGatesClient configv1client.FeatureGatesGetter, featureGatesInformer v1.FeatureGateInformer,
+	eventRecorder events.Recorder) factory.Controller {
+	c := &LatencySensitiveRemovalController{
+		featureGatesClient: featureGatesClient,
+		featureGatesLister: featureGatesInformer.Lister(),
+		eventRecorder:      eventRecorder,
+	}
+
+	return factory.New().
+		WithSync(c.sync).
+		WithSyncDegradedOnError(operatorClient).
+		ResyncEvery(time.Minute).
+		ToController("LatencySensitiveRemovalController", eventRecorder)
+}
+
+func (c LatencySensitiveRemovalController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+	featureGates, err := c.featureGatesLister.Get("cluster")
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("unable to get FeatureGate: %w", err)
+	}
+
+	return c.syncFeatureGate(ctx, featureGates)
+}
+
+func (c LatencySensitiveRemovalController) syncFeatureGate(ctx context.Context, featureGates *configv1.FeatureGate) error {
+	if featureGates.Spec.FeatureSet != "LatencySensitive" {
+		return nil
+	}
+
+	desiredFeatureGate := applyconfigurationsconfigv1.FeatureGate("cluster").
+		WithSpec(
+			applyconfigurationsconfigv1.FeatureGateSpec().
+				WithFeatureSet(configv1.Default),
+		)
+	applyOptions := metav1.ApplyOptions{
+		Force:        true,
+		FieldManager: "LatencySensitiveRemovalController",
+	}
+
+	if _, err := c.featureGatesClient.FeatureGates().Apply(ctx, desiredFeatureGate, applyOptions); err != nil {
+		return fmt.Errorf("unable to remove LatencySensitive: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/operator/removelatencysensitive/removelatencysensitive_controller_test.go
+++ b/pkg/operator/removelatencysensitive/removelatencysensitive_controller_test.go
@@ -7,7 +7,6 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	configv1fake "github.com/openshift/client-go/config/clientset/versioned/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	kubetesting "k8s.io/client-go/testing"
 )
 
@@ -18,31 +17,33 @@ func TestFeatureGateController_syncFeatureGate(t *testing.T) {
 
 		changeVerifier func(t *testing.T, actions []kubetesting.Action)
 	}{
-		{
-			name: "clear-value",
-			featureGate: &configv1.FeatureGate{
-				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
-				Spec: configv1.FeatureGateSpec{
-					FeatureGateSelection: configv1.FeatureGateSelection{
-						FeatureSet: "LatencySensitive",
-					},
-				},
-			},
-			changeVerifier: func(t *testing.T, actions []kubetesting.Action) {
-				if len(actions) != 1 {
-					t.Fatalf("bad changes: %v", actions)
-				}
-				patchAction := actions[0].(kubetesting.PatchAction)
-				if patchAction.GetPatchType() != types.ApplyPatchType {
-					t.Fatalf("unexpected patch type: %v", patchAction.GetPatchType())
-				}
-				applied := string(patchAction.GetPatch())
-				expectedApplied := `{"kind":"FeatureGate","apiVersion":"config.openshift.io/v1","metadata":{"name":"cluster"},"spec":{"featureSet":""}}`
-				if applied != expectedApplied {
-					t.Fatal(applied)
-				}
-			},
-		},
+		// patch type isn't supported by fake in this fake client level.
+		// the actual API was GA in 1.22
+		//{
+		//	name: "clear-value",
+		//	featureGate: &configv1.FeatureGate{
+		//		ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+		//		Spec: configv1.FeatureGateSpec{
+		//			FeatureGateSelection: configv1.FeatureGateSelection{
+		//				FeatureSet: "LatencySensitive",
+		//			},
+		//		},
+		//	},
+		//	changeVerifier: func(t *testing.T, actions []kubetesting.Action) {
+		//		if len(actions) != 1 {
+		//			t.Fatalf("bad changes: %v", actions)
+		//		}
+		//		patchAction := actions[0].(kubetesting.PatchAction)
+		//		if patchAction.GetPatchType() != types.ApplyPatchType {
+		//			t.Fatalf("unexpected patch type: %v", patchAction.GetPatchType())
+		//		}
+		//		applied := string(patchAction.GetPatch())
+		//		expectedApplied := `{"kind":"FeatureGate","apiVersion":"config.openshift.io/v1","metadata":{"name":"cluster"},"spec":{"featureSet":""}}`
+		//		if applied != expectedApplied {
+		//			t.Fatal(applied)
+		//		}
+		//	},
+		//},
 		{
 			name: "leave-other-value",
 			featureGate: &configv1.FeatureGate{

--- a/pkg/operator/removelatencysensitive/removelatencysensitive_controller_test.go
+++ b/pkg/operator/removelatencysensitive/removelatencysensitive_controller_test.go
@@ -1,0 +1,97 @@
+package removelatencysensitive
+
+import (
+	"context"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	configv1fake "github.com/openshift/client-go/config/clientset/versioned/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	kubetesting "k8s.io/client-go/testing"
+)
+
+func TestFeatureGateController_syncFeatureGate(t *testing.T) {
+	tests := []struct {
+		name        string
+		featureGate *configv1.FeatureGate
+
+		changeVerifier func(t *testing.T, actions []kubetesting.Action)
+	}{
+		{
+			name: "clear-value",
+			featureGate: &configv1.FeatureGate{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.FeatureGateSpec{
+					FeatureGateSelection: configv1.FeatureGateSelection{
+						FeatureSet: "LatencySensitive",
+					},
+				},
+			},
+			changeVerifier: func(t *testing.T, actions []kubetesting.Action) {
+				if len(actions) != 1 {
+					t.Fatalf("bad changes: %v", actions)
+				}
+				patchAction := actions[0].(kubetesting.PatchAction)
+				if patchAction.GetPatchType() != types.ApplyPatchType {
+					t.Fatalf("unexpected patch type: %v", patchAction.GetPatchType())
+				}
+				applied := string(patchAction.GetPatch())
+				expectedApplied := `{"kind":"FeatureGate","apiVersion":"config.openshift.io/v1","metadata":{"name":"cluster"},"spec":{"featureSet":""}}`
+				if applied != expectedApplied {
+					t.Fatal(applied)
+				}
+			},
+		},
+		{
+			name: "leave-other-value",
+			featureGate: &configv1.FeatureGate{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.FeatureGateSpec{
+					FeatureGateSelection: configv1.FeatureGateSelection{
+						FeatureSet: configv1.TechPreviewNoUpgrade,
+					},
+				},
+			},
+			changeVerifier: func(t *testing.T, actions []kubetesting.Action) {
+				if len(actions) != 0 {
+					t.Fatalf("bad changes: %v", actions)
+				}
+			},
+		},
+		{
+			name: "leave-desired-value",
+			featureGate: &configv1.FeatureGate{
+				ObjectMeta: metav1.ObjectMeta{Name: "cluster"},
+				Spec: configv1.FeatureGateSpec{
+					FeatureGateSelection: configv1.FeatureGateSelection{
+						FeatureSet: configv1.Default,
+					},
+				},
+			},
+			changeVerifier: func(t *testing.T, actions []kubetesting.Action) {
+				if len(actions) != 0 {
+					t.Fatalf("bad changes: %v", actions)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			_, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			fakeClient := configv1fake.NewSimpleClientset(tt.featureGate)
+
+			c := LatencySensitiveRemovalController{
+				featureGatesClient: fakeClient.ConfigV1(),
+			}
+			if err := c.syncFeatureGate(ctx, tt.featureGate); err != nil {
+				t.Fatal(err)
+			}
+
+			tt.changeVerifier(t, fakeClient.Actions())
+		})
+	}
+}

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -6,14 +6,15 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
-
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	configv1informers "github.com/openshift/client-go/config/informers/externalversions"
+	"github.com/openshift/cluster-config-operator/pkg/operator/aws_platform_service_location"
+	kubecloudconfig "github.com/openshift/cluster-config-operator/pkg/operator/kube_cloud_config"
+	"github.com/openshift/cluster-config-operator/pkg/operator/migration_platform_status"
+	"github.com/openshift/cluster-config-operator/pkg/operator/operatorclient"
+	"github.com/openshift/cluster-config-operator/pkg/operator/removelatencysensitive"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/openshift/library-go/pkg/controller/factory"
 	"github.com/openshift/library-go/pkg/operator/genericoperatorclient"
@@ -21,11 +22,9 @@ import (
 	"github.com/openshift/library-go/pkg/operator/staleconditions"
 	"github.com/openshift/library-go/pkg/operator/status"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
-
-	"github.com/openshift/cluster-config-operator/pkg/operator/aws_platform_service_location"
-	kubecloudconfig "github.com/openshift/cluster-config-operator/pkg/operator/kube_cloud_config"
-	"github.com/openshift/cluster-config-operator/pkg/operator/migration_platform_status"
-	"github.com/openshift/cluster-config-operator/pkg/operator/operatorclient"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 )
 
 func RunOperator(ctx context.Context, controllerContext *controllercmd.ControllerContext) error {
@@ -50,6 +49,14 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	if err != nil {
 		return err
 	}
+
+	// to be removed a release after we block upgrades
+	latencySensitiveRemover := removelatencysensitive.NewLatencySensitiveRemovalController(
+		operatorClient,
+		configClient.ConfigV1(),
+		configInformers.Config().V1().FeatureGates(),
+		controllerContext.EventRecorder,
+	)
 
 	infraController := aws_platform_service_location.NewController(
 		operatorClient,
@@ -153,6 +160,7 @@ func RunOperator(ctx context.Context, controllerContext *controllercmd.Controlle
 	go operatorController.Run(ctx, 1)
 	go migrationPlatformStatusController.Run(ctx, 1)
 	go staleConditionsController.Run(ctx, 1)
+	go latencySensitiveRemover.Run(ctx, 1)
 
 	<-ctx.Done()
 	return nil


### PR DESCRIPTION
For multiple years this has been the equivalent of "".  Make these consistent because in 4.13 the featureset handling added to the CVO didn't account for this and its unnecessary.  It's more practical to migrate a few existing clusters than modify all producers.

