### PR TITLE
[release-4.14] OCPBUGS-21653: Update openshift/api package to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 	github.com/go-bindata/go-bindata v3.1.2+incompatible
-	github.com/openshift/api v0.0.0-20231012190404-7b36cb38c7d0
+	github.com/openshift/api v0.0.0-20231031181504-3be12e93388f
 	github.com/openshift/build-machinery-go v0.0.0-20230306181456-d321ffa04533
 	github.com/openshift/client-go v0.0.0-20230718165156-6014fb98e86a
 	github.com/openshift/library-go v0.0.0-20231019174803-a2be4c7ba05f

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/onsi/ginkgo/v2 v2.9.2 h1:BA2GMJOtfGAfagzYtrAlufIP0lq6QERkFmHLMLPwFSU=
 github.com/onsi/gomega v1.27.4 h1:Z2AnStgsdSayCMDiCU42qIz+HLqEPcgiOCXjAU/w+8E=
-github.com/openshift/api v0.0.0-20231012190404-7b36cb38c7d0 h1:+XsCYpNsZ0Arx95PDvIbPnpkj4Cd8scHWdnMlNvXiKk=
-github.com/openshift/api v0.0.0-20231012190404-7b36cb38c7d0/go.mod h1:yimSGmjsI+XF1mr+AKBs2//fSXIOhhetHGbMlBEfXbs=
+github.com/openshift/api v0.0.0-20231031181504-3be12e93388f h1:j7QYl057TBD/lxWAGCr4IrbdG7IMg2U60DFK+BKt3VI=
+github.com/openshift/api v0.0.0-20231031181504-3be12e93388f/go.mod h1:yimSGmjsI+XF1mr+AKBs2//fSXIOhhetHGbMlBEfXbs=
 github.com/openshift/build-machinery-go v0.0.0-20230306181456-d321ffa04533 h1:mh3ZYs7kPIIe3UUY6tJcTExmtjnXXUu0MrBuK2W/Qvw=
 github.com/openshift/build-machinery-go v0.0.0-20230306181456-d321ffa04533/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/client-go v0.0.0-20230718165156-6014fb98e86a h1:ZKewwwEIURDnufm2oBd9rRvSp45BtRzPPrsUIFtm4V8=

--- a/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_infrastructure-CustomNoUpgrade.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_infrastructure-CustomNoUpgrade.crd.yaml
@@ -655,7 +655,7 @@ spec:
                                 description: key is the key part of the label. A label key can have a maximum of 63 characters and cannot be empty. Label key must begin with a lowercase letter, and must contain only lowercase letters, numeric characters, and the following special characters `_-`. Label key must not have the reserved prefixes `kubernetes-io` and `openshift-io`.
                                 maxLength: 63
                                 minLength: 1
-                                pattern: ^[a-z][0-9a-z_-]+$
+                                pattern: ^[a-z][0-9a-z_-]{0,62}$
                                 type: string
                                 x-kubernetes-validations:
                                   - message: label keys must not start with either `openshift-io` or `kubernetes-io`
@@ -664,7 +664,7 @@ spec:
                                 description: value is the value part of the label. A label value can have a maximum of 63 characters and cannot be empty. Value must contain only lowercase letters, numeric characters, and the following special characters `_-`.
                                 maxLength: 63
                                 minLength: 1
-                                pattern: ^[0-9a-z_-]+$
+                                pattern: ^[0-9a-z_-]{1,63}$
                                 type: string
                             required:
                               - key

--- a/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_infrastructure-TechPreviewNoUpgrade.crd.yaml
+++ b/vendor/github.com/openshift/api/config/v1/0000_10_config-operator_01_infrastructure-TechPreviewNoUpgrade.crd.yaml
@@ -655,7 +655,7 @@ spec:
                                 description: key is the key part of the label. A label key can have a maximum of 63 characters and cannot be empty. Label key must begin with a lowercase letter, and must contain only lowercase letters, numeric characters, and the following special characters `_-`. Label key must not have the reserved prefixes `kubernetes-io` and `openshift-io`.
                                 maxLength: 63
                                 minLength: 1
-                                pattern: ^[a-z][0-9a-z_-]+$
+                                pattern: ^[a-z][0-9a-z_-]{0,62}$
                                 type: string
                                 x-kubernetes-validations:
                                   - message: label keys must not start with either `openshift-io` or `kubernetes-io`
@@ -664,7 +664,7 @@ spec:
                                 description: value is the value part of the label. A label value can have a maximum of 63 characters and cannot be empty. Value must contain only lowercase letters, numeric characters, and the following special characters `_-`.
                                 maxLength: 63
                                 minLength: 1
-                                pattern: ^[0-9a-z_-]+$
+                                pattern: ^[0-9a-z_-]{1,63}$
                                 type: string
                             required:
                               - key

--- a/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
+++ b/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
@@ -622,7 +622,7 @@ type GCPResourceLabel struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:validation:Pattern=`^[a-z][0-9a-z_-]+$`
+	// +kubebuilder:validation:Pattern=`^[a-z][0-9a-z_-]{0,62}$`
 	Key string `json:"key"`
 
 	// value is the value part of the label. A label value can have a maximum of 63 characters and cannot be empty.
@@ -630,7 +630,7 @@ type GCPResourceLabel struct {
 	// +kubebuilder:validation:Required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=63
-	// +kubebuilder:validation:Pattern=`^[0-9a-z_-]+$`
+	// +kubebuilder:validation:Pattern=`^[0-9a-z_-]{1,63}$`
 	Value string `json:"value"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -163,7 +163,7 @@ github.com/modern-go/reflect2
 # github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822
 ## explicit
 github.com/munnerz/goautoneg
-# github.com/openshift/api v0.0.0-20231012190404-7b36cb38c7d0
+# github.com/openshift/api v0.0.0-20231031181504-3be12e93388f
 ## explicit; go 1.20
 github.com/openshift/api
 github.com/openshift/api/apiserver


### PR DESCRIPTION
PR is for updating the openshift/api package to the latest version which contains the API changes(https://github.com/openshift/api/pull/1630) having the fix for https://issues.redhat.com/browse/OCPBUGS-21653

Package updated using command
`go get github.com/openshift/api@release-4.14`