### PR TITLE
Revert "OCPBUGS-19106: Updating ose-cluster-config-operator-container image to be consistent with ART"

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.20-openshift-4.15 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.20-openshift-4.15 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-config-operator
 COPY . .
 ENV GO_PACKAGE github.com/openshift/cluster-config-operator
 RUN make build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.15:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.15:base
 RUN mkdir -p /usr/share/bootkube/manifests/manifests
 RUN mkdir -p /usr/share/bootkube/manifests/bootstrap-manifests
 COPY --from=builder /go/src/github.com/openshift/cluster-config-operator/vendor/github.com/openshift/api/config/v1/*_config-operator_*.yaml /usr/share/bootkube/manifests/manifests


### PR DESCRIPTION
Reverts openshift/cluster-config-operator#385

It's complicated, but while ART is building RHEL 9 HyperShift and cluster-config-operator images, both ART and CI are building mostly-RHEL-8 machine-config operator images.  HyperShift invokes both [some `machine-config-*` and the `cluster-config-operator` binaries][1].  And the MCO binaries are currently RHEL 8 both [in CI][2] and [in ART builds][3].  Moving the CI cluster-config operator back to RHEL 8 might give us some breathing room vs. current 4.15 release-controller blocker failures [like][4]:

```
=== NAME  TestCreateClusterProxy/ValidateHostedCluster
   util.go:218:
       failed to ensure guest nodes became ready, ready: (0/2):
       Unexpected error:
           <wait.errInterrupted>:
           timed out waiting for the condition
```

Because of [NodePool failures like][5]:

```
 - lastTransitionTime: "2023-12-04T17:38:58Z"
    message: |-
      Failed to generate payload: error getting ignition payload: failed to execute cluster-config-operator: cluster-config-operator process failed: /payloads/get-payload431072810/bin/cluster-config-operator: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by /payloads/get-payload431072810/bin/cluster-config-operator)
      /payloads/get-payload431072810/bin/cluster-config-operator: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /payloads/get-payload431072810/bin/cluster-config-operator)
      : exit status 1
    observedGeneration: 1
    reason: InvalidConfig
    status: ""
    type: ValidGeneratedPayload
```

[1]: https://github.com/openshift/hypershift/blob/7f8fcfb3f936c965d7fcf83f31a884ac11b82da2/ignition-server/controllers/local_ignitionprovider.go#L241-L290
[2]: https://github.com/openshift/hypershift/blob/7f8fcfb3f936c965d7fcf83f31a884ac11b82da2/ignition-server/controllers/local_ignitionprovider.go#L241-L290
[3]: https://github.com/openshift-eng/ocp-build-data/blob/openshift-4.15/images/ose-machine-config-operator.yml#L12
[4]: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-aws-ovn/1731724268011524096
[5]: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-hypershift-release-4.15-periodics-e2e-aws-ovn/1731724268011524096/artifacts/e2e-aws-ovn/run-e2e/artifacts/TestCreateCluster/namespaces/e2e-clusters-v7g4p/hypershift.openshift.io/nodepools/example-x6tdn-us-east-1c.yaml