### PR TITLE
Revert "OCPBUGS-26541: remove duplicate manifests in image"

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -7,6 +7,12 @@ RUN make build --warn-undefined-variables
 FROM registry.ci.openshift.org/ocp/4.15:base
 RUN mkdir -p /usr/share/bootkube/manifests/manifests
 RUN mkdir -p /usr/share/bootkube/manifests/bootstrap-manifests
+COPY --from=builder /go/src/github.com/openshift/cluster-config-operator/vendor/github.com/openshift/api/config/v1/*_config-operator_*.yaml /usr/share/bootkube/manifests/manifests
+COPY --from=builder /go/src/github.com/openshift/cluster-config-operator/vendor/github.com/openshift/api/quota/v1/*.crd.yaml /usr/share/bootkube/manifests/manifests
+COPY --from=builder /go/src/github.com/openshift/cluster-config-operator/vendor/github.com/openshift/api/security/v1/*.crd.yaml /usr/share/bootkube/manifests/manifests
+COPY --from=builder /go/src/github.com/openshift/cluster-config-operator/vendor/github.com/openshift/api/securityinternal/v1/*.crd.yaml /usr/share/bootkube/manifests/manifests
+COPY --from=builder /go/src/github.com/openshift/cluster-config-operator/vendor/github.com/openshift/api/authorization/v1/*.crd.yaml /usr/share/bootkube/manifests/manifests
+COPY --from=builder /go/src/github.com/openshift/cluster-config-operator/vendor/github.com/openshift/api/operator/v1alpha1/0000_10_config-operator_01_imagecontentsourcepolicy.crd.yaml /usr/share/bootkube/manifests/manifests
 COPY --from=builder /go/src/github.com/openshift/cluster-config-operator/cluster-config-operator /usr/bin/
 COPY manifests /manifests
 

--- a/empty-resources/0000_05_config-operator_02_apiserver.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_apiserver.cr.yaml
@@ -1,0 +1,12 @@
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    # this flag is not set for a cluster coming from 4.5 via upgrade. Hence, 4.5 clusters will keep supporting non-sha256 tokens.
+    oauth-apiserver.openshift.io/secure-token-storage: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/empty-resources/0000_05_config-operator_02_authentication.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_authentication.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Authentication
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/empty-resources/0000_05_config-operator_02_console.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_console.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Console
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/empty-resources/0000_05_config-operator_02_dns.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_dns.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: DNS
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/empty-resources/0000_05_config-operator_02_featuregate.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_featuregate.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/empty-resources/0000_05_config-operator_02_image.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_image.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Image
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/empty-resources/0000_05_config-operator_02_infrastructure.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_infrastructure.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Infrastructure
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/empty-resources/0000_05_config-operator_02_ingress.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_ingress.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Ingress
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/empty-resources/0000_05_config-operator_02_network.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_network.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/empty-resources/0000_05_config-operator_02_oauth.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_oauth.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/empty-resources/0000_05_config-operator_02_project.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_project.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Project
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/empty-resources/0000_05_config-operator_02_proxy.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_proxy.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Proxy
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/empty-resources/0000_05_config-operator_02_scheduler.cr.yaml
+++ b/empty-resources/0000_05_config-operator_02_scheduler.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Scheduler
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}

--- a/empty-resources/0000_10_config-operator_02_node.cr.yaml
+++ b/empty-resources/0000_10_config-operator_02_node.cr.yaml
@@ -1,0 +1,10 @@
+apiVersion: config.openshift.io/v1
+kind: Node
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+spec: {}


### PR DESCRIPTION
Reverts openshift/cluster-config-operator#392


Hypershift CI relies on these files and is the removal of these files is causing a CI failure.