### PR TITLE
OCPBUGS-28621: Add required PSa labels

### DIFF
--- a/manifests/0000_10_config-operator_01_openshift-config-ns.yaml
+++ b/manifests/0000_10_config-operator_01_openshift-config-ns.yaml
@@ -6,6 +6,9 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: openshift-config
   labels:
     openshift.io/run-level: "0"


### PR DESCRIPTION
This PR sets the required PSa labels for the `openshift-config` namespace.

Namespaces that don't define PSa labels currently get `restricted` by default; this results in violations from workloads that run in the `openshift-config` namespace, as this is a runlevel 0 namespace and likely these payloads need privileged policy.

See https://issues.redhat.com/browse/AUTH-262 for more information.