### PR TITLE
AUTH-481: Add missing PSa labels

### DIFF
--- a/manifests/0000_00_config-operator_00_namespace.yaml
+++ b/manifests/0000_00_config-operator_00_namespace.yaml
@@ -9,4 +9,7 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
   name: openshift-config-operator

--- a/manifests/0000_10_config-operator_01_openshift-config-managed-ns.yaml
+++ b/manifests/0000_10_config-operator_01_openshift-config-managed-ns.yaml
@@ -9,3 +9,6 @@ metadata:
   name: openshift-config-managed
   labels:
     openshift.io/run-level: "0"
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted


### PR DESCRIPTION
This PR adds the missing PSa labels to `openshift-config-managed` and `openshift-config-operator` namespaces.

/assign @deads2k 