### PR TITLE
[release-4.15] OCPBUGS-36151: Set required-scc for openshift workloads

### DIFF
--- a/manifests/0000_10_config-operator_07_deployment.yaml
+++ b/manifests/0000_10_config-operator_07_deployment.yaml
@@ -21,6 +21,7 @@ spec:
       name: openshift-config-operator
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: nonroot-v2
       labels:
         app: openshift-config-operator
     spec:


### PR DESCRIPTION
[OCPBUGS-36151](https://issues.redhat.com/browse/OCPBUGS-36151)

Manual cherry-pick of #410 