### PR TITLE
OCPBUGS-45477: Updating ose-cluster-config-operator-container image to be consistent with ART for 4.19

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.22-openshift-4.18
+  tag: rhel-9-release-golang-1.23-openshift-4.19

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-config-operator
 COPY . .
 ENV GO_PACKAGE github.com/openshift/cluster-config-operator
 RUN make build --warn-undefined-variables
 
-FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 RUN mkdir -p /usr/share/bootkube/manifests/manifests
 RUN mkdir -p /usr/share/bootkube/manifests/bootstrap-manifests
 COPY --from=builder /go/src/github.com/openshift/cluster-config-operator/cluster-config-operator /usr/bin/

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/openshift/cluster-config-operator
 
-go 1.22.0
-
-toolchain go1.22.3
+go 1.23.0
 
 require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc


### PR DESCRIPTION
Continuation of #429 which has not updated the go.mod to 1.23, and therefore is failing to verify