### PR TITLE
OCPBUGS-57187: featuregates: always complete featuregates when feature set is CustomNoUpgrade

### DIFF
--- a/pkg/operator/featuregates/featuregate_controller.go
+++ b/pkg/operator/featuregates/featuregate_controller.go
@@ -45,7 +45,8 @@ func NewFeatureGateController(
 	featureGatesClient configv1client.FeatureGatesGetter, featureGatesInformer v1.FeatureGateInformer,
 	clusterVersionInformer v1.ClusterVersionInformer,
 	versionRecorder status.VersionGetter,
-	eventRecorder events.Recorder) factory.Controller {
+	eventRecorder events.Recorder,
+) factory.Controller {
 	c := &FeatureGateController{
 		processVersion:       processVersion,
 		featureGatesClient:   featureGatesClient,
@@ -155,7 +156,7 @@ func featuresGatesFromFeatureSets(knownFeatureSets map[configv1.FeatureSet]*feat
 				featureGates.Spec.FeatureGateSelection.CustomNoUpgrade.Disabled,
 			)
 		}
-		return []configv1.FeatureGateName{}, []configv1.FeatureGateName{}, nil
+		return completeFeatureGatesForCustom(knownFeatureSets[configv1.Default], []configv1.FeatureGateName{}, []configv1.FeatureGateName{})
 	}
 
 	featureSet, ok := knownFeatureSets[featureGates.Spec.FeatureSet]


### PR DESCRIPTION
In OCPBUGS-57187 it was identified that setting only the `.spec.featureSet` field to `CustomNoUpgrade` and not configuring a value for the `.spec.customNoUpgrade` field in the `FeatureGate` API resulted in an empty enabled/disabled set of feature gates, leading to panics in various platform operators.

This PR ensures that even in this edge case, we always fill the list of enabled/disabled feature gates with the default set.
It also adds a unit test to capture this scenario.