### PR TITLE
add config cm and set safer cipherSuites for operator

### DIFF
--- a/manifests/0000_10_config-operator_02_configmap.yaml
+++ b/manifests/0000_10_config-operator_02_configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-config-operator
+  name: openshift-config-operator-config
+  annotations:
+    include.release.openshift.io/hypershift: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig
+    servingInfo:
+      cipherSuites:
+      - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+      - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+      - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+      - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      minTLSVersion: VersionTLS12

--- a/manifests/0000_10_config-operator_07_deployment.yaml
+++ b/manifests/0000_10_config-operator_07_deployment.yaml
@@ -40,6 +40,9 @@ spec:
       - name: available-featuregates
         emptyDir:
           sizeLimit: 100Mi
+      - name: config
+        configMap:
+          name: openshift-config-operator-config
       initContainers:
         - name: openshift-api
           securityContext:
@@ -77,6 +80,7 @@ spec:
           - operator
           - --operator-version=$(OPERATOR_IMAGE_VERSION)
           - --authoritative-feature-gate-dir=/available-featuregates
+          - --config=/var/run/configmaps/config/config.yaml
         ports:
           - containerPort: 8443
             name: metrics
@@ -104,6 +108,8 @@ spec:
           name: serving-cert
         - mountPath: /available-featuregates
           name: available-featuregates
+        - mountPath: /var/run/configmaps/config
+          name: config
         env:
         - name: IMAGE
           value: quay.io/openshift/origin-cluster-config-operator:v4.0


### PR DESCRIPTION
As the  openshift-config-operator log shows it uses `insecure cipher` suites:
```
I0707 04:28:51.656535       1 cmd.go:241] Using service-serving-cert provided certificates
I0707 04:28:51.656863       1 leaderelection.go:122] The leader election gives 4 retries and allows for 30s of clock skew. The kube-apiserver downtime tolerance is 78s. Worst non-graceful lease acquisition is 2m43s. Worst graceful lease acquisition is {26s}.
I0707 04:28:51.657907       1 observer_polling.go:159] Starting file observer
I0707 04:28:51.692682       1 builder.go:299] config-operator version 4.16.0-202408081442.p0.g441d29c.assembly.stream.el9-441d29c-441d29c92b1759d1780a525112e764280b78b0d6
I0707 04:28:52.070266       1 secure_serving.go:57] Forcing use of http/1.1 only
W0707 04:28:52.070287       1 secure_serving.go:69] Use of insecure cipher 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256' detected.
W0707 04:28:52.070292       1 secure_serving.go:69] Use of insecure cipher 'TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256' detected.
I0707 04:28:52.074875       1 leaderelection.go:250] attempting to acquire leader lease openshift-config-operator/config-operator-lock...
```