### PR TITLE
CNTRLPLANE-1544: manifests: Use restricted-v3 scc for deployment

### DIFF
--- a/manifests/0000_10_config-operator_07_deployment.yaml
+++ b/manifests/0000_10_config-operator_07_deployment.yaml
@@ -21,13 +21,13 @@ spec:
       name: openshift-config-operator
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
-        openshift.io/required-scc: nonroot-v2
+        openshift.io/required-scc: restricted-v3
       labels:
         app: openshift-config-operator
     spec:
+      hostUsers: false
       securityContext:
         runAsNonRoot: true
-        runAsUser: 65534
         seccompProfile:
           type: RuntimeDefault
       serviceAccountName: openshift-config-operator


### PR DESCRIPTION
This effectively enforces user namespace.