### PR TITLE
CNF-23046: Migrate away from deprecated ioutil

### DIFF
--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -2,7 +2,6 @@ package render
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -123,7 +122,7 @@ func (r *renderOpts) Run() error {
 	renderConfig := TemplateData{}
 
 	if len(r.clusterConfigFile) > 0 {
-		_, err := ioutil.ReadFile(r.clusterConfigFile)
+		_, err := os.ReadFile(r.clusterConfigFile)
 		if err != nil {
 			return err
 		}
@@ -158,7 +157,7 @@ func (r *renderOpts) Run() error {
 		if err := os.MkdirAll(filepath.Dir(r.cloudProviderConfigOutputFile), 0755); err != nil {
 			return fmt.Errorf("failed to create %v: %w", r.cloudProviderConfigOutputFile, err)
 		}
-		if err := ioutil.WriteFile(r.cloudProviderConfigOutputFile, targetCloudConfigMapData, 0644); err != nil {
+		if err := os.WriteFile(r.cloudProviderConfigOutputFile, targetCloudConfigMapData, 0644); err != nil {
 			return fmt.Errorf("failed to write merged config to %q: %v", r.cloudProviderConfigOutputFile, err)
 		}
 	}

--- a/pkg/operator/kube_cloud_config/bootstrap.go
+++ b/pkg/operator/kube_cloud_config/bootstrap.go
@@ -2,7 +2,6 @@ package kubecloudconfig
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
@@ -34,7 +33,7 @@ func BootstrapTransform(infrastructureFile string, cloudProviderFile string) ([]
 
 	// Read, parse, and save the infrastructure object
 	var clusterInfrastructure configv1.Infrastructure
-	fileData, err := ioutil.ReadFile(infrastructureFile)
+	fileData, err := os.ReadFile(infrastructureFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read infrastructure file: %w", err)
 	}
@@ -46,7 +45,7 @@ func BootstrapTransform(infrastructureFile string, cloudProviderFile string) ([]
 	// Read, parse, and save the user provided cloud configmap
 	var cloudProviderConfigInput corev1.ConfigMap
 	if len(cloudProviderFile) > 0 {
-		fileData, err = ioutil.ReadFile(cloudProviderFile)
+		fileData, err = os.ReadFile(cloudProviderFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read cloud provider file: %w", err)
 		}


### PR DESCRIPTION
`ioutil` has been deprecated since Go 1.16: https://go.dev/doc/go1.16#ioutil

Tracking issue: https://github.com/redhat-best-practices-for-k8s/telco-bot/issues/52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced deprecated file I/O calls with modern standard library equivalents to remove a legacy dependency and improve maintainability; internal-only change with no user-facing behavior differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->