### PR TITLE
SPLAT-2747: Updated kube cloud config controller to react to feature gate updates

### DIFF
--- a/pkg/operator/kube_cloud_config/controller.go
+++ b/pkg/operator/kube_cloud_config/controller.go
@@ -2,7 +2,6 @@ package kubecloudconfig
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -42,10 +41,7 @@ type KubeCloudConfigController struct {
 	infraLister     configv1listers.InfrastructureLister
 	configMapClient corev1client.ConfigMapsGetter
 
-	// currentFeatureGates stores the most recently observed feature gates
-	// Protected by featureGatesMu
-	currentFeatureGates featuregates.FeatureGate
-	featureGatesMu      sync.RWMutex
+	featureGateAccessor featuregates.FeatureGateAccess
 
 	// transformers stores per platform tranformer
 	cloudConfigTransformers map[configv1.PlatformType]cloudConfigTransformer
@@ -63,31 +59,8 @@ func NewController(operatorClient operatorv1helpers.OperatorClient,
 		infraLister:             infraLister,
 		configMapClient:         configMapClient,
 		cloudConfigTransformers: cloudConfigTransformers(),
+		featureGateAccessor:     featureGateAccess,
 	}
-
-	// Initialize current feature gates if available
-	if featureGateAccess.AreInitialFeatureGatesObserved() {
-		currentFeatures, err := featureGateAccess.CurrentFeatureGates()
-		if err != nil {
-			klog.Warningf("unable to get current feature gates during controller initialization: %v", err)
-		} else {
-			c.featureGatesMu.Lock()
-			c.currentFeatureGates = currentFeatures
-			c.featureGatesMu.Unlock()
-		}
-	}
-
-	// Create change handler for when feature settings change
-	featureGateAccess.SetChangeHandler(func(featureChange featuregates.FeatureChange) {
-		currentFeatures, err := featureGateAccess.CurrentFeatureGates()
-		if err != nil {
-			klog.Warningf("unable to get current feature gates during change event: %v", err)
-		} else {
-			c.featureGatesMu.Lock()
-			c.currentFeatureGates = currentFeatures
-			c.featureGatesMu.Unlock()
-		}
-	})
 
 	return factory.New().
 		WithInformers(
@@ -128,7 +101,8 @@ func (c *KubeCloudConfigController) sync(ctx context.Context, syncCtx factory.Sy
 		return err
 	}
 	if !shouldManage {
-		syncCtx.Recorder().Eventf("KubeCloudConfigController", "Skipping kube-cloud-config management for platform %s", platformName)
+		// Set log level to 4 instead of using an event recorder due to this logging / happening every minute.
+		klog.V(4).Infof("KubeCloudConfigController: Skipping kube-cloud-config management for platform %s", platformName)
 		return nil
 	}
 
@@ -245,15 +219,14 @@ func (c *KubeCloudConfigController) shouldManageCloudConfig(platformType configv
 // It uses the feature gates that were retrieved during controller initialization.
 // If feature gates weren't available at initialization, it returns false as a safe fallback.
 func (c *KubeCloudConfigController) isFeatureGateEnabled(gateName configv1.FeatureGateName) bool {
-	c.featureGatesMu.RLock()
-	defer c.featureGatesMu.RUnlock()
-
-	if c.currentFeatureGates == nil {
+	if !c.featureGateAccessor.AreInitialFeatureGatesObserved() {
 		// Feature gates weren't initialized, return safe fallback
 		klog.Warningf("unable to check featuregate %v due to currentFeatureGates == nil", gateName)
 		return false
 	}
 
-	klog.V(4).Infof("is featuregate %v enabled?  %v", gateName, c.currentFeatureGates.Enabled(gateName))
-	return c.currentFeatureGates.Enabled(gateName)
+	// We can ignore error since only time error happens if initial feature gates were not observed and we checked above
+	currentFeatureGates, _ := c.featureGateAccessor.CurrentFeatureGates()
+	klog.V(4).Infof("is featuregate %v enabled?  %v", gateName, currentFeatureGates.Enabled(gateName))
+	return currentFeatureGates.Enabled(gateName)
 }

--- a/pkg/operator/kube_cloud_config/controller.go
+++ b/pkg/operator/kube_cloud_config/controller.go
@@ -2,6 +2,7 @@ package kubecloudconfig
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -42,7 +43,9 @@ type KubeCloudConfigController struct {
 	configMapClient corev1client.ConfigMapsGetter
 
 	// currentFeatureGates stores the most recently observed feature gates
+	// Protected by featureGatesMu
 	currentFeatureGates featuregates.FeatureGate
+	featureGatesMu      sync.RWMutex
 
 	// transformers stores per platform tranformer
 	cloudConfigTransformers map[configv1.PlatformType]cloudConfigTransformer
@@ -68,9 +71,23 @@ func NewController(operatorClient operatorv1helpers.OperatorClient,
 		if err != nil {
 			klog.Warningf("unable to get current feature gates during controller initialization: %v", err)
 		} else {
+			c.featureGatesMu.Lock()
 			c.currentFeatureGates = currentFeatures
+			c.featureGatesMu.Unlock()
 		}
 	}
+
+	// Create change handler for when feature settings change
+	featureGateAccess.SetChangeHandler(func(featureChange featuregates.FeatureChange) {
+		currentFeatures, err := featureGateAccess.CurrentFeatureGates()
+		if err != nil {
+			klog.Warningf("unable to get current feature gates during change event: %v", err)
+		} else {
+			c.featureGatesMu.Lock()
+			c.currentFeatureGates = currentFeatures
+			c.featureGatesMu.Unlock()
+		}
+	})
 
 	return factory.New().
 		WithInformers(
@@ -85,7 +102,7 @@ func NewController(operatorClient operatorv1helpers.OperatorClient,
 		ToController("KubeCloudConfigController", recorder)
 }
 
-func (c KubeCloudConfigController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
+func (c *KubeCloudConfigController) sync(ctx context.Context, syncCtx factory.SyncContext) error {
 	obj, err := c.infraLister.Get("cluster")
 	if apierrors.IsNotFound(err) {
 		syncCtx.Recorder().Warningf("KubeCloudConfigController", "Required infrastructures.%s/cluster not found", configv1.GroupName)
@@ -192,7 +209,7 @@ func cloudConfigTransformers() map[configv1.PlatformType]cloudConfigTransformer 
 // shouldManageCloudConfig determines whether this controller should manage the kube-cloud-config
 // ConfigMap for the given platform type. This allows for platform-specific logic to determine
 // when ownership should transfer to another operator.
-func (c KubeCloudConfigController) shouldManageCloudConfig(platformType configv1.PlatformType) (bool, error) {
+func (c *KubeCloudConfigController) shouldManageCloudConfig(platformType configv1.PlatformType) (bool, error) {
 	switch platformType {
 	case configv1.VSpherePlatformType:
 		// For vSphere, check if VSphereMultiVCenterDay2 feature gate is enabled
@@ -227,11 +244,16 @@ func (c KubeCloudConfigController) shouldManageCloudConfig(platformType configv1
 // isFeatureGateEnabled checks if the specified feature gate is enabled in the cluster.
 // It uses the feature gates that were retrieved during controller initialization.
 // If feature gates weren't available at initialization, it returns false as a safe fallback.
-func (c KubeCloudConfigController) isFeatureGateEnabled(gateName configv1.FeatureGateName) bool {
+func (c *KubeCloudConfigController) isFeatureGateEnabled(gateName configv1.FeatureGateName) bool {
+	c.featureGatesMu.RLock()
+	defer c.featureGatesMu.RUnlock()
+
 	if c.currentFeatureGates == nil {
 		// Feature gates weren't initialized, return safe fallback
+		klog.Warningf("unable to check featuregate %v due to currentFeatureGates == nil", gateName)
 		return false
 	}
 
+	klog.V(4).Infof("is featuregate %v enabled?  %v", gateName, c.currentFeatureGates.Enabled(gateName))
 	return c.currentFeatureGates.Enabled(gateName)
 }

--- a/pkg/operator/kube_cloud_config/controller_test.go
+++ b/pkg/operator/kube_cloud_config/controller_test.go
@@ -219,13 +219,12 @@ SubnetID = subnet-test
 
 			// Create a feature gate accessor with no enabled feature gates
 			featureGateAccessor := featuregates.NewHardcodedFeatureGateAccess(nil, nil)
-			currentFeatureGates, _ := featureGateAccessor.CurrentFeatureGates()
 
 			ctrl := KubeCloudConfigController{
 				infraClient:             fakeConfig.ConfigV1().Infrastructures(),
 				infraLister:             configv1listers.NewInfrastructureLister(indexerInfra),
 				configMapClient:         fake.CoreV1(),
-				currentFeatureGates:     currentFeatureGates,
+				featureGateAccessor:     featureGateAccessor,
 				cloudConfigTransformers: cloudConfigTransformers(),
 			}
 
@@ -369,14 +368,11 @@ func Test_sync_withVSphereMultiVCenterDay2FeatureGate(t *testing.T) {
 
 			fakeConfig := configfakeclient.NewClientset(inputInfra)
 
-			// Get the current feature gates from the accessor
-			currentFeatureGates, _ := featureGateAccessor.CurrentFeatureGates()
-
 			ctrl := KubeCloudConfigController{
 				infraClient:             fakeConfig.ConfigV1().Infrastructures(),
 				infraLister:             configv1listers.NewInfrastructureLister(indexerInfra),
 				configMapClient:         fake.CoreV1(),
-				currentFeatureGates:     currentFeatureGates,
+				featureGateAccessor:     featureGateAccessor,
 				cloudConfigTransformers: cloudConfigTransformers(),
 			}
 

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -37,11 +38,12 @@ import (
 	"github.com/openshift/library-go/pkg/operator/status"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	"github.com/spf13/pflag"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
 )
 
@@ -104,12 +106,11 @@ func (o *OperatorOptions) RunOperator(ctx context.Context, controllerContext *co
 		configInformers.Config().V1().FeatureGates(),
 		controllerContext.EventRecorder,
 	)
-	go featureGateAccessor.Run(ctx)
 
 	// don't change any versions until we sync
 	versionRecorder := status.NewVersionGetter()
 	clusterOperator, err := configClient.ConfigV1().ClusterOperators().Get(ctx, "config-operator", metav1.GetOptions{})
-	if err != nil && !errors.IsNotFound(err) {
+	if err != nil && !k8serrors.IsNotFound(err) {
 		return err
 	}
 	for _, version := range clusterOperator.Status.Versions {
@@ -163,18 +164,6 @@ func (o *OperatorOptions) RunOperator(ctx context.Context, controllerContext *co
 		controllerContext.EventRecorder,
 	)
 
-	kubeCloudConfigController := kubecloudconfig.NewController(
-		operatorClient,
-		configClient.ConfigV1(),
-		configInformers.Config().V1().Infrastructures().Lister(),
-		configInformers.Config().V1().Infrastructures().Informer(),
-		v1helpers.CachedConfigMapGetter(kubeClient.CoreV1(), kubeInformersForNamespaces),
-		kubeInformersForNamespaces.InformersFor(operatorclient.GlobalUserSpecifiedConfigNamespace).Core().V1().ConfigMaps().Informer(),
-		kubeInformersForNamespaces.InformersFor(operatorclient.GlobalMachineSpecifiedConfigNamespace).Core().V1().ConfigMaps().Informer(),
-		featureGateAccessor,
-		controllerContext.EventRecorder,
-	)
-
 	migrationPlatformStatusController := migration_platform_status.NewController(
 		operatorClient,
 		configClient.ConfigV1(),
@@ -198,6 +187,36 @@ func (o *OperatorOptions) RunOperator(ctx context.Context, controllerContext *co
 		versionRecorder,
 		controllerContext.EventRecorder,
 		controllerContext.Clock,
+	)
+
+	// Start informers before waiting for feature gates - the feature gate accessor needs them running
+	go dynamicInformers.Start(ctx.Done())
+	go configInformers.Start(ctx.Done())
+	go kubeInformersForNamespaces.Start(ctx.Done())
+
+	// Start the feature gate accessor and wait for it to observe initial feature gates
+	// This must happen before creating controllers that depend on feature gates
+	go featureGateAccessor.Run(ctx)
+	klog.Info("Started feature gate accessor")
+	select {
+	case <-featureGateAccessor.InitialFeatureGatesObserved():
+		klog.V(4).Info("FeatureGates initialized")
+	case <-time.After(1 * time.Minute):
+		accessError := errors.New("timed out waiting for FeatureGate detection")
+		klog.Error(accessError, "unable to start operator")
+		return accessError
+	}
+
+	kubeCloudConfigController := kubecloudconfig.NewController(
+		operatorClient,
+		configClient.ConfigV1(),
+		configInformers.Config().V1().Infrastructures().Lister(),
+		configInformers.Config().V1().Infrastructures().Informer(),
+		v1helpers.CachedConfigMapGetter(kubeClient.CoreV1(), kubeInformersForNamespaces),
+		kubeInformersForNamespaces.InformersFor(operatorclient.GlobalUserSpecifiedConfigNamespace).Core().V1().ConfigMaps().Informer(),
+		kubeInformersForNamespaces.InformersFor(operatorclient.GlobalMachineSpecifiedConfigNamespace).Core().V1().ConfigMaps().Informer(),
+		featureGateAccessor,
+		controllerContext.EventRecorder,
 	)
 
 	logLevelController := loglevel.NewClusterOperatorLoggingController(operatorClient, controllerContext.EventRecorder)
@@ -238,9 +257,7 @@ func (o *OperatorOptions) RunOperator(ctx context.Context, controllerContext *co
 		controllerContext.EventRecorder,
 	)
 
-	go dynamicInformers.Start(ctx.Done())
-	go configInformers.Start(ctx.Done())
-	go kubeInformersForNamespaces.Start(ctx.Done())
+	// Informers were already started earlier before waiting for feature gates
 
 	go infraController.Run(ctx, 1)
 	go kubeCloudConfigController.Run(ctx, 1)

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -189,24 +189,6 @@ func (o *OperatorOptions) RunOperator(ctx context.Context, controllerContext *co
 		controllerContext.Clock,
 	)
 
-	// Start informers before waiting for feature gates - the feature gate accessor needs them running
-	go dynamicInformers.Start(ctx.Done())
-	go configInformers.Start(ctx.Done())
-	go kubeInformersForNamespaces.Start(ctx.Done())
-
-	// Start the feature gate accessor and wait for it to observe initial feature gates
-	// This must happen before creating controllers that depend on feature gates
-	go featureGateAccessor.Run(ctx)
-	klog.Info("Started feature gate accessor")
-	select {
-	case <-featureGateAccessor.InitialFeatureGatesObserved():
-		klog.V(4).Info("FeatureGates initialized")
-	case <-time.After(1 * time.Minute):
-		accessError := errors.New("timed out waiting for FeatureGate detection")
-		klog.Error(accessError, "unable to start operator")
-		return accessError
-	}
-
 	kubeCloudConfigController := kubecloudconfig.NewController(
 		operatorClient,
 		configClient.ConfigV1(),
@@ -257,7 +239,30 @@ func (o *OperatorOptions) RunOperator(ctx context.Context, controllerContext *co
 		controllerContext.EventRecorder,
 	)
 
-	// Informers were already started earlier before waiting for feature gates
+	// Start informers before waiting for feature gates - the feature gate accessor needs them running
+	go dynamicInformers.Start(ctx.Done())
+	go configInformers.Start(ctx.Done())
+	go kubeInformersForNamespaces.Start(ctx.Done())
+
+	// The featuregate controller must never be featuregated. It is responsible for ensuring the featuregate
+	// object status contains the correct feature gate states for the current release.  During upgrades, FGC will set
+	// the version field that the accessor will be checking; therefore, it must run before the featuregeate accessor
+	// as the accessor will fail to start if its version isn't updated.
+	go featureGateController.Run(ctx, 1)
+
+	// Start the feature gate accessor and wait for it to observe initial feature gates
+	// This must happen before creating controllers that depend on feature gates (such as kube cloud config controller)
+	go featureGateAccessor.Run(ctx)
+
+	klog.Info("Started feature gate accessor")
+	select {
+	case <-featureGateAccessor.InitialFeatureGatesObserved():
+		klog.Info("FeatureGates initialized")
+	case <-time.After(5 * time.Minute):
+		accessError := errors.New("timed out waiting for FeatureGate detection")
+		klog.Error(accessError, "unable to start operator")
+		return accessError
+	}
 
 	go infraController.Run(ctx, 1)
 	go kubeCloudConfigController.Run(ctx, 1)
@@ -266,7 +271,6 @@ func (o *OperatorOptions) RunOperator(ctx context.Context, controllerContext *co
 	go operatorController.Run(ctx, 1)
 	go migrationPlatformStatusController.Run(ctx, 1)
 	go staleConditionsController.Run(ctx, 1)
-	go featureGateController.Run(ctx, 1)
 	go latencySensitiveRemover.Run(ctx, 1)
 	go okdFeatureSetMigrator.Run(ctx, 1)
 	go featureUpgradeableController.Run(ctx, 1)


### PR DESCRIPTION
[SPLAT-2747](https://redhat.atlassian.net/browse/SPLAT-2747)

### Changes
- Changed logic for accessing feature gates to be done directly through accessor to prevent race conditions
- Fixed starting of FeatureGateAccessor to be in step w/ all required informers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feature gates now synchronize dynamically at runtime without requiring restarts.

* **Improvements**
  * Operator startup waits for feature-gate observation (with a brief timeout) before starting dependent controllers, preventing premature runs.
  * Clearer runtime warnings when feature gates are uninitialized and additional debug-level logs when evaluating gates.
  * Cloud-config management decisions now respect current feature-gate state and use debug logs instead of startup events.

* **Tests**
  * Tests updated to use the runtime feature-gate accessor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->