### PR TITLE
CNTRLPLANE-3423: feat: have CVO inject the centralized TLS configuration into the operator's config

### DIFF
--- a/manifests/0000_10_config-operator_06_configmap.yaml
+++ b/manifests/0000_10_config-operator_06_configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: openshift-config-operator
+  name: openshift-config-operator-config
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    config.openshift.io/inject-tls: "true"
+data:
+  config.yaml: |
+    apiVersion: operator.openshift.io/v1alpha1
+    kind: GenericOperatorConfig

--- a/manifests/0000_10_config-operator_07_deployment.yaml
+++ b/manifests/0000_10_config-operator_07_deployment.yaml
@@ -40,6 +40,9 @@ spec:
       - name: available-featuregates
         emptyDir:
           sizeLimit: 100Mi
+      - name: config
+        configMap:
+          name: openshift-config-operator-config
       initContainers:
         - name: openshift-api
           securityContext:
@@ -75,6 +78,10 @@ spec:
         command:
           - cluster-config-operator
           - operator
+          - --config=/var/run/configmaps/config/config.yaml
+          - --terminate-on-files=/var/run/configmaps/config/config.yaml
+          - --terminate-on-files=/var/run/secrets/serving-cert/tls.crt
+          - --terminate-on-files=/var/run/secrets/serving-cert/tls.key
           - --operator-version=$(OPERATOR_IMAGE_VERSION)
           - --authoritative-feature-gate-dir=/available-featuregates
         ports:
@@ -104,6 +111,8 @@ spec:
           name: serving-cert
         - mountPath: /available-featuregates
           name: available-featuregates
+        - mountPath: /var/run/configmaps/config
+          name: config
         env:
         - name: IMAGE
           value: quay.io/openshift/origin-cluster-config-operator:v4.0


### PR DESCRIPTION
Also, have the operator restart whenever the config changes.

wip-docs: https://github.com/openshift/enhancements/pull/2020

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced configuration management for the config operator with explicit file path declarations.
  * Implemented automatic termination monitoring for configuration and certificate files, ensuring the operator gracefully responds to configuration and security credential changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->