### PR TITLE
CNTRLPLANE-2270: Update README with operator responsibilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ Do not file security issues as public GitHub issues.
 
 ## License
 
-cluster-config-operator is licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/).
+cluster-config-operator is licensed under the [Apache License, Version 2.0](https://github.com/openshift/cluster-config-operator/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,43 +1,92 @@
-# cluster-config-operator
+# OpenShift Cluster Config Operator
 
-This repo is not open for control loop contributions.
-This repo only exists to hold the CRD manifests required to bootstrap a cluster, it is not a place to add logic because jointly owned repos
-like this one end up having no owner to handle migration over time as dependencies move.
+The cluster-config-operator manages OpenShift cluster configuration with a minimal set of runtime controllers. It provides:
 
-The canonical location for OpenShift cluster configuration. This repo includes:
- 1. The source of all CRD manifests for config.openshift.io
- 2. A render command which creates the initial CRs for all config.openshift.io resource.
+1. A render command which creates initial bootstrap manifests
+2. Controllers for managing specific cluster configuration aspects
 
-## Tests
+**Note:** This repo is not accepting new control loop contributions. It has a constrained scope and should not be expanded with additional logic — jointly owned repos like this end up having no owner to handle migration over time as dependencies move.
 
-This repository is compatible with the [OpenShift Tests Extension (OTE)](https://github.com/openshift-eng/openshift-tests-extension) framework.
+## Building
 
-### Building the test binary
+To build the operator and test binary:
 
 ```bash
 make build
 ```
 
-### Running test suites and tests
+This produces:
+- `cluster-config-operator` — the operator binary
+- `cluster-config-operator-tests-ext` — the test binary compatible with the OpenShift Tests Extension framework
+
+## Controllers
+
+The operator runs the following controllers:
+
+- **Feature Gates Controller** — Manages feature gate configuration and version tracking for the cluster
+- **Kube Cloud Config Controller** — Synthesizes cloud provider configuration for Kubernetes components from Infrastructure and user-provided ConfigMaps
+- **AWS Platform Service Location Controller** — Configures AWS service endpoints for platform components
+- **Platform Status Migration Controller** — Handles migration of platform status fields in Infrastructure
+- **Feature Upgradeable Controller** — Controls cluster upgradeability based on feature gate configuration
+- **Latency Sensitive Removal Controller** — Manages removal of deprecated latency-sensitive workload class (temporary migration controller)
+- **OKD Feature Set Migration Controller** — Handles migration of Default featureset to OKD for OKD builds (temporary migration controller)
+
+## Testing
+
+This repository uses the [OpenShift Tests Extension (OTE)](https://github.com/openshift-eng/openshift-tests-extension) framework.
+
+### Running tests
 
 ```bash
-# Run a specific test suite or test
+# Run all tests in the suite
 ./cluster-config-operator-tests-ext run-suite openshift/cluster-config-operator/all
+
+# Run a specific test
 ./cluster-config-operator-tests-ext run-test "test-name"
 
-# Run with JUnit output
+# Generate JUnit output
 ./cluster-config-operator-tests-ext run-suite openshift/cluster-config-operator/all --junit-path /tmp/junit.xml
 ```
 
-### Listing available tests and suites
+### Listing tests
 
 ```bash
 # List all test suites
 ./cluster-config-operator-tests-ext list suites
 
-# List tests in a suite
+# List tests in a specific suite
 ./cluster-config-operator-tests-ext list tests --suite=openshift/cluster-config-operator/all
 ```
 
-For more information about the OTE framework, see the [openshift-tests-extension documentation](https://github.com/openshift-eng/openshift-tests-extension).
+For more information, see the [OpenShift Tests Extension documentation](https://github.com/openshift-eng/openshift-tests-extension).
 
+## Dependencies
+
+Dependencies are managed through [Go Modules](https://github.com/golang/go/wiki/Modules).
+
+When updating dependencies:
+
+```bash
+go mod tidy
+go mod vendor
+```
+
+### Key Dependencies
+
+| Repository | Role |
+|---|---|
+| [openshift/api](https://github.com/openshift/api) | OCP API type definitions including config.openshift.io |
+| [openshift/client-go](https://github.com/openshift/client-go) | Typed clients for OCP resources |
+| [openshift/library-go](https://github.com/openshift/library-go) | Shared OCP library code and controller framework |
+| [openshift/build-machinery-go](https://github.com/openshift/build-machinery-go) | Standard Makefile targets |
+| [k8s.io/client-go](https://github.com/kubernetes/client-go) | Kubernetes API client library |
+
+## Security
+
+If you've found a security issue that you'd like to disclose confidentially, please contact Red Hat's Product Security team. Details at https://access.redhat.com/security/team/contact
+
+Do not file security issues as public GitHub issues.
+
+## License
+
+cluster-config-operator is licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/).


### PR DESCRIPTION
  Update ReadMe file with correct information(README contained outdated information that could mislead contributors and users about the operator's actual scope and responsibilities.)

 ## Summary
  Update the README to accurately reflect the cluster-config-operator's current responsibilities and remove outdated information.

  ## Changes
  - Remove outdated claim about being the source of CRD manifests for config.openshift.io (CRDs were moved to the api)
  - Clarify that the operator has a minimal set of controllers but is not accepting new ones
  - Document the actual controllers running in the operator:
    - Feature Gates Controller
    - Kube Cloud Config Controller
    - AWS Platform Service Location Controller
    - Platform Status Migration Controller
    - Feature Upgradeable Controller
    - Latency Sensitive Removal Controller (temporary migration)
    - OKD Feature Set Migration Controller (temporary migration)
  - Add accurate descriptions of controllers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked the README into a more structured, operator-focused overview of responsibilities.
  * Documented the set of runtime controllers and their roles.
  * Restructured the Testing section with clearer instructions for building, running, and listing tests (including JUnit output).
  * Added a Dependencies section with a key-references table.
  * Expanded Security guidance and updated the license notice to Apache License 2.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->