### PR TITLE
OCPBUGS-104562: Mark kube-cloud-config recreation test disruptive

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -462,7 +462,7 @@ var _ = g.Describe("cluster-config-operator", func() {
 		o.Expect(hasDataKey || hasBinaryKey).To(o.BeTrue(), "kube-cloud-config ConfigMap should contain 'cloud.conf' key")
 	})
 
-	g.It("should reconcile and recreate kube-cloud-config when deleted [apigroup:config.openshift.io][Operator][Serial]", func() {
+	g.It("should reconcile and recreate kube-cloud-config when deleted [apigroup:config.openshift.io][Operator][Serial][Disruptive]", func() {
 		config, err := getClientConfig()
 		o.Expect(err).NotTo(o.HaveOccurred(), "failed to get client config")
 


### PR DESCRIPTION
These bugs and fixes were automatically generated by a payload-agent experiment to improve resilience and diagnostics for infrastructure failures. Please review the PR and either shepherd it to merge or close it. If the work is incorrect or unhelpful, a brief comment would help us improve. Thanks, and apologies if we missed the mark.

## What changed

Add the `[Disruptive]` label to the serial test that deletes and verifies recreation of `kube-cloud-config`.

The test remains `[Serial]`, preserving its isolation requirement. The additional label excludes it from `openshift/cluster-config-operator/conformance/serial` and selects it for `openshift/cluster-config-operator/operator/disruptive`, which has parallelism 1 and uses disruptive cluster-stability expectations.

## Why

The test deliberately deletes `openshift-config-managed/kube-cloud-config`. Although cluster-config-operator recreates it and the test passes, machine-config-operator can observe the brief absence and correctly set `Degraded=True` with `RenderConfigFailed`. The continuously running legacy CVO monitor then fails the conformance job for the transient degradation.

Running the test serially prevents overlap with other e2e tests, but it does not serialize cluster controllers or stop the monitor. Whether MCO observes the deletion window is timing-dependent, producing a recurring false failure across unrelated jobs.

Example failure: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/31464/pull-ci-openshift-origin-main-e2e-aws-ovn-serial-2of2/2083347007321149440

## Impact

The destructive reconciliation coverage continues to run in isolation, but under the suite intended for tests that may temporarily affect cluster stability. This avoids treating the expected MCO degradation as a conformance regression.

## Validation

- `GOFLAGS=-mod=mod go test ./cmd/cluster-config-operator-tests-ext ./test/e2e`
- Confirmed with the extension CLI that the test no longer matches the serial conformance suite and does match the disruptive suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Marked the kube-cloud-config deletion and recreation end-to-end test as disruptive.
  * No changes were made to test behavior or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->